### PR TITLE
Feat : 장부 CRUD

### DIFF
--- a/src/main/java/nbdream/accountBook/config/QueryDslConfig.java
+++ b/src/main/java/nbdream/accountBook/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package nbdream.accountBook.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/nbdream/accountBook/controller/AccountBookController.java
+++ b/src/main/java/nbdream/accountBook/controller/AccountBookController.java
@@ -38,8 +38,17 @@ public class AccountBookController {
     //장부 내역 수정
     @PutMapping("/update/{accountbook-history-id}")
     public ApiResponse<Void> updatePost(@RequestBody PutAccountBookReqDto request,
+                                        @AuthenticatedMemberId Long memberId,
                                         @PathVariable("accountbook-history-id") final Long accountBookHistoryId) {
+        return accountBookHistoryService.updateAccountBookHistory(request, memberId, accountBookHistoryId);
+    }
 
-        return accountBookHistoryService.updateAccountBookHistory(request, accountBookHistoryId);
+    //장부 상세 조회
+
+    //장부 삭제
+    @DeleteMapping("/delete/{accountbook-history-id}")
+    public ApiResponse<Void> deleteAccountBookHistory(@AuthenticatedMemberId Long memberId,
+                                                      @PathVariable("accountbook-history-id") final Long accountBookHistoryId) {
+        return accountBookHistoryService.deleteAccountBookHistory(memberId, accountBookHistoryId);
     }
 }

--- a/src/main/java/nbdream/accountBook/controller/AccountBookController.java
+++ b/src/main/java/nbdream/accountBook/controller/AccountBookController.java
@@ -3,10 +3,7 @@ package nbdream.accountBook.controller;
 import lombok.RequiredArgsConstructor;
 import nbdream.accountBook.service.AccountBookHistoryService;
 import nbdream.accountBook.service.AccountBookService;
-import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
-import nbdream.accountBook.service.dto.GetAccountBookListResDto;
-import nbdream.accountBook.service.dto.PostAccountBookReqDto;
-import nbdream.accountBook.service.dto.PutAccountBookReqDto;
+import nbdream.accountBook.service.dto.*;
 import nbdream.auth.config.AuthenticatedMemberId;
 import nbdream.common.advice.response.ApiResponse;
 import org.springframework.web.bind.annotation.*;
@@ -36,19 +33,24 @@ public class AccountBookController {
     }
 
     //장부 내역 수정
-    @PutMapping("/update/{accountbook-history-id}")
+    @PutMapping("/update/{account-book-history-id}")
     public ApiResponse<Void> updatePost(@RequestBody PutAccountBookReqDto request,
                                         @AuthenticatedMemberId Long memberId,
-                                        @PathVariable("accountbook-history-id") final Long accountBookHistoryId) {
+                                        @PathVariable("account-book-history-id") final Long accountBookHistoryId) {
         return accountBookHistoryService.updateAccountBookHistory(request, memberId, accountBookHistoryId);
     }
 
     //장부 상세 조회
-
+    @GetMapping("/detail/{account-book-history-id}")
+    public ApiResponse<GetAccountBookDetailResDto> getMyAccountBookList(@AuthenticatedMemberId Long memberId,
+                                                                        @PathVariable("account-book-history-id") final Long accountBookHistoryId){
+        GetAccountBookDetailResDto response = accountBookHistoryService.getAccountBookDetail(memberId, accountBookHistoryId);
+        return ApiResponse.ok(response);
+    }
     //장부 삭제
-    @DeleteMapping("/delete/{accountbook-history-id}")
+    @DeleteMapping("/delete/{account-book-history-id}")
     public ApiResponse<Void> deleteAccountBookHistory(@AuthenticatedMemberId Long memberId,
-                                                      @PathVariable("accountbook-history-id") final Long accountBookHistoryId) {
+                                                      @PathVariable("account-book-history-id") final Long accountBookHistoryId) {
         return accountBookHistoryService.deleteAccountBookHistory(memberId, accountBookHistoryId);
     }
 }

--- a/src/main/java/nbdream/accountBook/controller/AccountBookController.java
+++ b/src/main/java/nbdream/accountBook/controller/AccountBookController.java
@@ -6,33 +6,40 @@ import nbdream.accountBook.service.AccountBookService;
 import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
 import nbdream.accountBook.service.dto.GetAccountBookListResDto;
 import nbdream.accountBook.service.dto.PostAccountBookReqDto;
+import nbdream.accountBook.service.dto.PutAccountBookReqDto;
 import nbdream.auth.config.AuthenticatedMemberId;
 import nbdream.common.advice.response.ApiResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/auth/account")
 public class AccountBookController {
 
     private final AccountBookService accountBookService;
     private final AccountBookHistoryService accountBookHistoryService;
 
     //내 장부 조회
-    @GetMapping("/auth/account")
-    public ApiResponse<GetAccountBookListResDto> getMyAccountBookList( @RequestBody GetAccountBookListReqDto reqDto,
+    @GetMapping
+    public ApiResponse<GetAccountBookListResDto> getMyAccountBookList( @RequestBody GetAccountBookListReqDto request,
                                                                        @AuthenticatedMemberId Long memberId){
-        GetAccountBookListResDto resDto = accountBookService.getMyAccountBookList(reqDto, memberId);
-        return ApiResponse.ok(resDto);
+        GetAccountBookListResDto response = accountBookService.getMyAccountBookList(request, memberId);
+        return ApiResponse.ok(response);
     }
 
     //장부 작성
-    @PostMapping("/auth/account/register")
-    public ApiResponse<Void> writeAccountBookHistory(@RequestBody PostAccountBookReqDto reqDto,
+    @PostMapping("/register")
+    public ApiResponse<Void> writeAccountBookHistory(@RequestBody PostAccountBookReqDto request,
                                                      @AuthenticatedMemberId Long memberId) {
-        return accountBookHistoryService.writeAccountBookHistory(reqDto, memberId);
+        return accountBookHistoryService.writeAccountBookHistory(request, memberId);
+    }
+
+    //장부 내역 수정
+    @PutMapping("/update/{accountbook-history-id}")
+    public ApiResponse<Void> updatePost(@RequestBody PutAccountBookReqDto request,
+                                        @PathVariable("accountbook-history-id") final Long accountBookHistoryId) {
+
+        return accountBookHistoryService.updateAccountBookHistory(request, accountBookHistoryId);
     }
 }

--- a/src/main/java/nbdream/accountBook/controller/AccountBookController.java
+++ b/src/main/java/nbdream/accountBook/controller/AccountBookController.java
@@ -1,12 +1,15 @@
 package nbdream.accountBook.controller;
 
 import lombok.RequiredArgsConstructor;
+import nbdream.accountBook.service.AccountBookHistoryService;
 import nbdream.accountBook.service.AccountBookService;
 import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
 import nbdream.accountBook.service.dto.GetAccountBookListResDto;
+import nbdream.accountBook.service.dto.PostAccountBookReqDto;
 import nbdream.auth.config.AuthenticatedMemberId;
 import nbdream.common.advice.response.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountBookController {
 
     private final AccountBookService accountBookService;
+    private final AccountBookHistoryService accountBookHistoryService;
 
     //내 장부 조회
     @GetMapping("/auth/account")
@@ -23,5 +27,12 @@ public class AccountBookController {
                                                                        @AuthenticatedMemberId Long memberId){
         GetAccountBookListResDto resDto = accountBookService.getMyAccountBookList(reqDto, memberId);
         return ApiResponse.ok(resDto);
+    }
+
+    //장부 작성
+    @PostMapping("/auth/account/register")
+    public ApiResponse<Void> writeAccountBookHistory(@RequestBody PostAccountBookReqDto reqDto,
+                                                     @AuthenticatedMemberId Long memberId) {
+        return accountBookHistoryService.writeAccountBookHistory(reqDto, memberId);
     }
 }

--- a/src/main/java/nbdream/accountBook/controller/AccountBookController.java
+++ b/src/main/java/nbdream/accountBook/controller/AccountBookController.java
@@ -1,5 +1,7 @@
 package nbdream.accountBook.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import nbdream.accountBook.service.AccountBookHistoryService;
 import nbdream.accountBook.service.AccountBookService;
@@ -12,12 +14,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth/account")
+@Tag(name = "AccountBook Controller")
 public class AccountBookController {
 
     private final AccountBookService accountBookService;
     private final AccountBookHistoryService accountBookHistoryService;
 
-    //내 장부 조회
+    @Operation(summary = "내 장부 조회", description = "")
     @GetMapping
     public ApiResponse<GetAccountBookListResDto> getMyAccountBookList( @RequestBody GetAccountBookListReqDto request,
                                                                        @AuthenticatedMemberId Long memberId){
@@ -25,14 +28,14 @@ public class AccountBookController {
         return ApiResponse.ok(response);
     }
 
-    //장부 작성
+    @Operation(summary = "장부 작성", description = "")
     @PostMapping("/register")
     public ApiResponse<Void> writeAccountBookHistory(@RequestBody PostAccountBookReqDto request,
                                                      @AuthenticatedMemberId Long memberId) {
         return accountBookHistoryService.writeAccountBookHistory(request, memberId);
     }
 
-    //장부 내역 수정
+    @Operation(summary = "장부 내역 수정", description = "")
     @PutMapping("/update/{account-book-history-id}")
     public ApiResponse<Void> updatePost(@RequestBody PutAccountBookReqDto request,
                                         @AuthenticatedMemberId Long memberId,
@@ -40,14 +43,15 @@ public class AccountBookController {
         return accountBookHistoryService.updateAccountBookHistory(request, memberId, accountBookHistoryId);
     }
 
-    //장부 상세 조회
+    @Operation(summary = "장부 상세 조회", description = "")
     @GetMapping("/detail/{account-book-history-id}")
     public ApiResponse<GetAccountBookDetailResDto> getMyAccountBookList(@AuthenticatedMemberId Long memberId,
                                                                         @PathVariable("account-book-history-id") final Long accountBookHistoryId){
         GetAccountBookDetailResDto response = accountBookHistoryService.getAccountBookDetail(memberId, accountBookHistoryId);
         return ApiResponse.ok(response);
     }
-    //장부 삭제
+
+    @Operation(summary = "장부 삭제", description = "")
     @DeleteMapping("/delete/{account-book-history-id}")
     public ApiResponse<Void> deleteAccountBookHistory(@AuthenticatedMemberId Long memberId,
                                                       @PathVariable("account-book-history-id") final Long accountBookHistoryId) {

--- a/src/main/java/nbdream/accountBook/domain/AccountBook.java
+++ b/src/main/java/nbdream/accountBook/domain/AccountBook.java
@@ -23,6 +23,9 @@ public class AccountBook extends BaseEntity {
     @JoinColumn(name = "member_id", referencedColumnName = "id")
     private Member member;
 
+    @OneToMany(mappedBy = "accountBook", cascade = CascadeType.ALL)
+    private List<AccountBookHistory> accountBookHistoryList;
+
     @Builder
     public AccountBook(Member member) {
         this.member = member;

--- a/src/main/java/nbdream/accountBook/domain/AccountBookHistory.java
+++ b/src/main/java/nbdream/accountBook/domain/AccountBookHistory.java
@@ -3,6 +3,8 @@ package nbdream.accountBook.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import nbdream.common.entity.BaseEntity;
+import nbdream.member.domain.Member;
+
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.format.TextStyle;
@@ -57,5 +59,9 @@ public class AccountBookHistory extends BaseEntity {
     public String getKoreanDayOfWeek() {
         DayOfWeek dayOfWeek = this.dateTime.getDayOfWeek();
         return dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN);
+    }
+
+    public boolean isWriter(Long memberId, AccountBookHistory accountBookHistory){
+        return memberId.equals(accountBookHistory.accountBook.getMember().getId());
     }
 }

--- a/src/main/java/nbdream/accountBook/domain/AccountBookHistory.java
+++ b/src/main/java/nbdream/accountBook/domain/AccountBookHistory.java
@@ -45,6 +45,15 @@ public class AccountBookHistory extends BaseEntity {
         this.dateTime = dateTime;
     }
 
+    public void update(final AccountBook accountBook, final AccountBookCategory accountBookCategory, final TransactionType transactionType, final Long amount, final String content, final LocalDateTime dateTime) {
+        this.accountBook = accountBook;
+        this.accountBookCategory = accountBookCategory;
+        this.transactionType = transactionType;
+        this.amount = amount;
+        this.content = content;
+        this.dateTime = dateTime;
+    }
+
     public String getKoreanDayOfWeek() {
         DayOfWeek dayOfWeek = this.dateTime.getDayOfWeek();
         return dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN);

--- a/src/main/java/nbdream/accountBook/domain/AccountBookHistory.java
+++ b/src/main/java/nbdream/accountBook/domain/AccountBookHistory.java
@@ -7,6 +7,7 @@ import nbdream.member.domain.Member;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Locale;
 
@@ -63,5 +64,10 @@ public class AccountBookHistory extends BaseEntity {
 
     public boolean isWriter(Long memberId, AccountBookHistory accountBookHistory){
         return memberId.equals(accountBookHistory.accountBook.getMember().getId());
+    }
+
+    public String getDateTimeToString() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return this.dateTime.format(formatter);
     }
 }

--- a/src/main/java/nbdream/accountBook/domain/AccountBookHistory.java
+++ b/src/main/java/nbdream/accountBook/domain/AccountBookHistory.java
@@ -1,13 +1,10 @@
 package nbdream.accountBook.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import nbdream.common.entity.BaseEntity;
 import java.time.DayOfWeek;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.TextStyle;
 import java.util.Locale;
 
@@ -32,23 +29,24 @@ public class AccountBookHistory extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private TransactionType transactionType;
 
-    private int amount;
+    private Long amount;
 
     private String content;
 
-    private LocalDate date;
+    private LocalDateTime dateTime;
 
-    public AccountBookHistory(final AccountBook accountBook, final AccountBookCategory accountBookCategory, final TransactionType transactionType, final int amount, final String content, final LocalDate date) {
+    @Builder
+    public AccountBookHistory(final AccountBook accountBook, final AccountBookCategory accountBookCategory, final TransactionType transactionType, final Long amount, final String content, final LocalDateTime dateTime) {
         this.accountBook = accountBook;
         this.accountBookCategory = accountBookCategory;
         this.transactionType = transactionType;
         this.amount = amount;
         this.content = content;
-        this.date = date;
+        this.dateTime = dateTime;
     }
 
     public String getKoreanDayOfWeek() {
-        DayOfWeek dayOfWeek = this.date.getDayOfWeek();
+        DayOfWeek dayOfWeek = this.dateTime.getDayOfWeek();
         return dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN);
     }
 }

--- a/src/main/java/nbdream/accountBook/exception/AccountBookHistoryNotFoundException.java
+++ b/src/main/java/nbdream/accountBook/exception/AccountBookHistoryNotFoundException.java
@@ -1,0 +1,9 @@
+package nbdream.accountBook.exception;
+
+import nbdream.common.exception.NotFoundException;
+
+public class AccountBookHistoryNotFoundException extends NotFoundException {
+    public AccountBookHistoryNotFoundException() {
+        super("해당하는 장부 내역을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/nbdream/accountBook/exception/AccountBookNotFoundException.java
+++ b/src/main/java/nbdream/accountBook/exception/AccountBookNotFoundException.java
@@ -1,0 +1,9 @@
+package nbdream.accountBook.exception;
+
+import nbdream.common.exception.NotFoundException;
+
+public class AccountBookNotFoundException extends NotFoundException {
+    public AccountBookNotFoundException() {
+        super("장부를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/nbdream/accountBook/exception/DateNotFoundException.java
+++ b/src/main/java/nbdream/accountBook/exception/DateNotFoundException.java
@@ -1,0 +1,9 @@
+package nbdream.accountBook.exception;
+
+import nbdream.common.exception.NotFoundException;
+
+public class DateNotFoundException extends NotFoundException {
+    public DateNotFoundException() {
+        super("날짜 정보를 읽어올 수 없습니다.");
+    }
+}

--- a/src/main/java/nbdream/accountBook/exception/ImageNotFoundException.java
+++ b/src/main/java/nbdream/accountBook/exception/ImageNotFoundException.java
@@ -1,0 +1,9 @@
+package nbdream.accountBook.exception;
+
+import nbdream.common.exception.NotFoundException;
+
+public class ImageNotFoundException extends NotFoundException {
+    public ImageNotFoundException() {
+        super("이미지를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/nbdream/accountBook/exception/InvalidDateFormatException.java
+++ b/src/main/java/nbdream/accountBook/exception/InvalidDateFormatException.java
@@ -1,0 +1,7 @@
+package nbdream.accountBook.exception;
+
+public class InvalidDateFormatException extends IllegalArgumentException {
+    public InvalidDateFormatException() {
+        super("날짜 형식이 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/nbdream/accountBook/exception/UnAccessableAccountBookException.java
+++ b/src/main/java/nbdream/accountBook/exception/UnAccessableAccountBookException.java
@@ -1,0 +1,9 @@
+package nbdream.accountBook.exception;
+
+import nbdream.common.exception.BadRequestException;
+
+public class UnAccessableAccountBookException extends BadRequestException {
+    public UnAccessableAccountBookException() {
+        super("장부 내역에 접근할 수 없습니다.");
+    }
+}

--- a/src/main/java/nbdream/accountBook/exception/UnEditableAccountBookException.java
+++ b/src/main/java/nbdream/accountBook/exception/UnEditableAccountBookException.java
@@ -1,0 +1,10 @@
+package nbdream.accountBook.exception;
+
+import nbdream.common.exception.BadRequestException;
+import nbdream.common.exception.NotFoundException;
+
+public class UnEditableAccountBookException extends BadRequestException {
+    public UnEditableAccountBookException() {
+        super("장부를 수정, 삭제 할 수 없습니다.");
+    }
+}

--- a/src/main/java/nbdream/accountBook/repository/AccountBookHistoryRepository.java
+++ b/src/main/java/nbdream/accountBook/repository/AccountBookHistoryRepository.java
@@ -1,14 +1,19 @@
 package nbdream.accountBook.repository;
 
 import nbdream.accountBook.domain.AccountBookHistory;
+import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
+
+import java.util.List;
 
 
 public interface AccountBookHistoryRepository
         extends JpaRepository<AccountBookHistory, Long>,
         JpaSpecificationExecutor<AccountBookHistory>,
-        PagingAndSortingRepository<AccountBookHistory, Long> {
+        PagingAndSortingRepository<AccountBookHistory, Long>,
+        AccountBookHistoryRepositoryCustom {
 
+    List<AccountBookHistory> findByMemberIdAndCursor(Long memberId, Long cursor, int maxResults, GetAccountBookListReqDto request);
 }

--- a/src/main/java/nbdream/accountBook/repository/AccountBookHistoryRepositoryCustom.java
+++ b/src/main/java/nbdream/accountBook/repository/AccountBookHistoryRepositoryCustom.java
@@ -1,0 +1,12 @@
+package nbdream.accountBook.repository;
+
+import nbdream.accountBook.domain.AccountBookHistory;
+import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+
+public interface AccountBookHistoryRepositoryCustom {
+    List<AccountBookHistory> findByMemberIdAndCursor(Long memberId, Long cursor, int pageSize, GetAccountBookListReqDto reqDto);
+}

--- a/src/main/java/nbdream/accountBook/repository/AccountBookHistoryRepositoryCustomImpl.java
+++ b/src/main/java/nbdream/accountBook/repository/AccountBookHistoryRepositoryCustomImpl.java
@@ -1,0 +1,75 @@
+package nbdream.accountBook.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import nbdream.accountBook.domain.*;
+import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class AccountBookHistoryRepositoryCustomImpl implements AccountBookHistoryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AccountBookHistory> findByMemberIdAndCursor(Long memberId, Long cursorId, int maxResults, GetAccountBookListReqDto reqDto) {
+        QAccountBookHistory accountBookHistory = QAccountBookHistory.accountBookHistory;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(accountBookHistory.accountBook.member.id.eq(memberId));
+
+        if (reqDto.getCategory() != null && StringUtils.isNotBlank(reqDto.getCategory())) {
+            AccountBookCategory categoryEnum = AccountBookCategory.fromValue(reqDto.getCategory());
+            builder.and(accountBookHistory.accountBookCategory.eq(categoryEnum));
+        }
+
+        if (reqDto.getStart() != null && StringUtils.isNotBlank(reqDto.getStart())) {
+            LocalDate startDate = LocalDate.parse(reqDto.getStart());
+            LocalDateTime startDateTime = startDate.atStartOfDay();
+            builder.and(accountBookHistory.dateTime.goe(startDateTime));
+        }
+        if (reqDto.getEnd() != null && StringUtils.isNotBlank(reqDto.getEnd())) {
+            LocalDate endDate = LocalDate.parse(reqDto.getEnd());
+            LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+            builder.and(accountBookHistory.dateTime.loe(endDateTime));
+        }
+
+        if (reqDto.getTransactionType() != null && StringUtils.isNotBlank(reqDto.getTransactionType())) {
+            TransactionType transactionTypeEnum = TransactionType.fromValue(reqDto.getTransactionType());
+            builder.and(accountBookHistory.transactionType.eq(transactionTypeEnum));
+        }
+
+        boolean isDESC = true;  // 내림차순 or 오름차순 확인
+        if (reqDto.getSort() != null && StringUtils.isNotBlank(reqDto.getSort())) {
+            if (Sort.fromValue(reqDto.getSort()) == Sort.EARLIEST) {
+                isDESC = false;
+            }
+        }
+
+        JPAQuery<AccountBookHistory> query = queryFactory.selectFrom(accountBookHistory).where(builder);
+
+        if (cursorId == null || cursorId == 0) {
+            query.orderBy(accountBookHistory.id.desc()).limit(2);
+        } else {
+            if (isDESC) {
+                builder.and(accountBookHistory.id.lt(cursorId));
+                query.orderBy(accountBookHistory.dateTime.desc());
+            } else {
+                builder.and(accountBookHistory.id.gt(cursorId));
+                query.orderBy(accountBookHistory.dateTime.asc());
+            }
+
+            query.where(builder).limit(maxResults);
+        }
+
+        return query.fetch();
+    }
+}

--- a/src/main/java/nbdream/accountBook/repository/specifications/AccountBookHistorySpecifications.java
+++ b/src/main/java/nbdream/accountBook/repository/specifications/AccountBookHistorySpecifications.java
@@ -5,6 +5,7 @@ import nbdream.accountBook.domain.AccountBookHistory;
 import nbdream.accountBook.domain.TransactionType;
 import nbdream.accountBook.domain.Sort;
 import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.jpa.domain.Specification;
 
 import jakarta.persistence.criteria.Predicate;
@@ -23,31 +24,31 @@ public class AccountBookHistorySpecifications {
             predicates.add(criteriaBuilder.equal(root.get("accountBook").get("member").get("id"), memberId));
 
             // 카테고리
-            if (reqDto.getCategory() != null) {
+            if (reqDto.getCategory() != null && StringUtils.isNotBlank(reqDto.getCategory())) {
                 AccountBookCategory categoryEnum = AccountBookCategory.fromValue(reqDto.getCategory());
                 predicates.add(criteriaBuilder.equal(root.get("accountBookCategory"), categoryEnum));
             }
 
             // 날짜
-            if (reqDto.getStart() != null) {
+            if (reqDto.getStart() != null && StringUtils.isNotBlank(reqDto.getStart())) {
                 LocalDate startDate = LocalDate.parse(reqDto.getStart());
                 LocalDateTime startDateTime = startDate.atStartOfDay();
                 predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("dateTime"), startDateTime));
             }
-            if (reqDto.getEnd() != null) {
+            if (reqDto.getEnd() != null && StringUtils.isNotBlank(reqDto.getEnd())) {
                 LocalDate endDate = LocalDate.parse(reqDto.getEnd());
                 LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
                 predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("dateTime"), endDateTime));
             }
 
             // 수입/지출
-            if (reqDto.getTransactionType() != null) {
+            if (reqDto.getTransactionType() != null && StringUtils.isNotBlank(reqDto.getTransactionType())) {
                 TransactionType transactionTypeEnum = TransactionType.fromValue(reqDto.getTransactionType());
                 predicates.add(criteriaBuilder.equal(root.get("transactionType"), transactionTypeEnum));
             }
 
             // 날짜순
-            if (reqDto.getSort() != null) {
+            if (reqDto.getSort() != null && StringUtils.isNotBlank(reqDto.getSort())) {
                 Sort sortEnum = Sort.fromValue(reqDto.getSort());
                 if (sortEnum == Sort.EARLIEST) {
                     query.orderBy(criteriaBuilder.desc(root.get("dateTime")));

--- a/src/main/java/nbdream/accountBook/repository/specifications/AccountBookHistorySpecifications.java
+++ b/src/main/java/nbdream/accountBook/repository/specifications/AccountBookHistorySpecifications.java
@@ -41,8 +41,8 @@ public class AccountBookHistorySpecifications {
             }
 
             // 수입/지출
-            if (reqDto.getCost() != null) {
-                TransactionType transactionTypeEnum = TransactionType.fromValue(reqDto.getCost());
+            if (reqDto.getTransactionType() != null) {
+                TransactionType transactionTypeEnum = TransactionType.fromValue(reqDto.getTransactionType());
                 predicates.add(criteriaBuilder.equal(root.get("transactionType"), transactionTypeEnum));
             }
 

--- a/src/main/java/nbdream/accountBook/repository/specifications/AccountBookHistorySpecifications.java
+++ b/src/main/java/nbdream/accountBook/repository/specifications/AccountBookHistorySpecifications.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.domain.Specification;
 
 import jakarta.persistence.criteria.Predicate;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,11 +31,13 @@ public class AccountBookHistorySpecifications {
             // 날짜
             if (reqDto.getStart() != null) {
                 LocalDate startDate = LocalDate.parse(reqDto.getStart());
-                predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("date"), startDate));
+                LocalDateTime startDateTime = startDate.atStartOfDay();
+                predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("dateTime"), startDateTime));
             }
             if (reqDto.getEnd() != null) {
                 LocalDate endDate = LocalDate.parse(reqDto.getEnd());
-                predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("date"), endDate));
+                LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+                predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("dateTime"), endDateTime));
             }
 
             // 수입/지출
@@ -46,9 +50,9 @@ public class AccountBookHistorySpecifications {
             if (reqDto.getSort() != null) {
                 Sort sortEnum = Sort.fromValue(reqDto.getSort());
                 if (sortEnum == Sort.EARLIEST) {
-                    query.orderBy(criteriaBuilder.desc(root.get("date")));
+                    query.orderBy(criteriaBuilder.desc(root.get("dateTime")));
                 } else if (sortEnum == Sort.OLDEST) {
-                    query.orderBy(criteriaBuilder.asc(root.get("date")));
+                    query.orderBy(criteriaBuilder.asc(root.get("dateTime")));
                 }
             }
 

--- a/src/main/java/nbdream/accountBook/service/AccountBookHistoryService.java
+++ b/src/main/java/nbdream/accountBook/service/AccountBookHistoryService.java
@@ -8,21 +8,10 @@ import nbdream.accountBook.domain.TransactionType;
 import nbdream.accountBook.exception.AccountBookNotFoundException;
 import nbdream.accountBook.repository.AccountBookHistoryRepository;
 import nbdream.accountBook.repository.AccountBookRepository;
-import nbdream.accountBook.repository.specifications.AccountBookHistorySpecifications;
-import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
-import nbdream.accountBook.service.dto.GetAccountBookResDto;
 import nbdream.accountBook.service.dto.PostAccountBookReqDto;
 import nbdream.common.advice.response.ApiResponse;
-import nbdream.image.domain.Image;
 import nbdream.image.repository.ImageRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,54 +20,7 @@ public class AccountBookHistoryService {
     private final AccountBookRepository accountBookRepository;
     private final AccountBookHistoryRepository accountBookHistoryRepository;
     private final ImageRepository imageRepository;
-    private static final int PAGE_SIZE = 3;     // 페이지 크기
 
-    //장부내역의 카테고리 항목을 리스트로 반환
-    public List<String> getCategoryList() {
-        return List.of(AccountBookCategory.values())
-                .stream()
-                .map(AccountBookCategory::getValue)
-                .collect(Collectors.toList());
-    }
-
-    // 내 장부 내역을 리스트로 반환
-    public List<AccountBookHistory> getMyAccountBookHistoryList(GetAccountBookListReqDto reqDto, Long memberId) {
-        Pageable pageable = PageRequest.of(reqDto.getPage(), PAGE_SIZE);
-        Specification<AccountBookHistory> spec = AccountBookHistorySpecifications.withFilters(reqDto, memberId);
-        Page<AccountBookHistory> historyPage = accountBookHistoryRepository.findAll(spec, pageable);
-        return historyPage.getContent();
-    }
-
-    // 장부 내역을 dtoList로 변환
-    public List<GetAccountBookResDto> convertToDtoList(List<AccountBookHistory> historyList) {
-        return historyList.stream()
-                .map(this::convertToDto)
-                .collect(Collectors.toList());
-    }
-
-    // 장부 내역을 dto로 변환
-    private GetAccountBookResDto convertToDto(AccountBookHistory history) {
-        List<Image> imgList = imageRepository.findAllByTargetId(history.getId());
-
-        String imgUrl = imgList.stream()
-                .findFirst()
-                .map(Image::getStoredPath)
-                .orElse(null);
-
-        return GetAccountBookResDto.builder()
-                .id(history.getId().toString())                         //장부 내역의 id
-                .title(history.getContent())
-                .category(history.getAccountBookCategory().getValue())
-                .year(history.getDateTime().getYear())
-                .month(history.getDateTime().getMonthValue())
-                .day(history.getDateTime().getDayOfMonth())
-                .dayName(history.getKoreanDayOfWeek())
-                .expense(history.getTransactionType() == TransactionType.EXPENSE ? (long) history.getAmount() : null)
-                .revenue(history.getTransactionType() == TransactionType.REVENUE ? (long) history.getAmount() : null)
-                .thumbnail(imgUrl)
-                .imageSize(imgList.size())
-                .build();
-    }
 
     //장부 작성
     public ApiResponse<Void> writeAccountBookHistory(PostAccountBookReqDto reqDto, Long memberId) {

--- a/src/main/java/nbdream/accountBook/service/AccountBookHistoryService.java
+++ b/src/main/java/nbdream/accountBook/service/AccountBookHistoryService.java
@@ -47,7 +47,9 @@ public class AccountBookHistoryService {
                 .build();
         accountBookHistoryRepository.save(accountBookHistory);
 
-        updateImageTargetId(request.getImageUrls(), accountBookHistory);
+        request.getImageUrls()
+                .stream()
+                .forEach(url -> imageRepository.save(new Image(accountBookHistory.getId(), url)));
         return ApiResponse.ok();
     }
 
@@ -70,7 +72,9 @@ public class AccountBookHistoryService {
         );
         accountBookHistoryRepository.save(accountBookHistory);
 
-        updateImageTargetId(request.getImageUrls(), accountBookHistory);
+        request.getImageUrls()
+                .stream()
+                .forEach(url -> imageRepository.save(new Image(accountBookHistory.getId(), url)));
         return ApiResponse.ok();
     }
 
@@ -95,16 +99,4 @@ public class AccountBookHistoryService {
         return ApiResponse.ok();
     }
 
-    //이미지 타겟id 업데이트
-    @Transactional
-    public void updateImageTargetId(List<String> imageUrlList, AccountBookHistory accountBookHistory){
-        if(imageUrlList == null){
-            return;
-        }
-        for(String url : imageUrlList){
-            Image image = imageRepository.findByImageUrl(url).orElseThrow(ImageNotFoundException::new);
-            image.update(accountBookHistory.getId());
-            imageRepository.save(image);
-        }
-    }
 }

--- a/src/main/java/nbdream/accountBook/service/AccountBookHistoryService.java
+++ b/src/main/java/nbdream/accountBook/service/AccountBookHistoryService.java
@@ -87,10 +87,11 @@ public class AccountBookHistoryService {
         if(!accountBookHistory.isWriter(memberId, accountBookHistory)){
             throw new UnEditableAccountBookException();
         }
-        List<Image> imageList = imageRepository.findAllByTargetId(accountBookHistory.getId());
+        //이미지 삭제 (추후 이미지Service에서 처리할 것임)
+        /*List<Image> imageList = imageRepository.findAllByTargetId(accountBookHistory.getId());
         imageRepository.findAllByTargetId(accountBookHistory.getId())
                 .stream()
-                .forEach(image -> imageRepository.delete(image));
+                .forEach(image -> imageRepository.delete(image));*/
 
         accountBookHistoryRepository.delete(accountBookHistory);
         return ApiResponse.ok();

--- a/src/main/java/nbdream/accountBook/service/AccountBookHistoryService.java
+++ b/src/main/java/nbdream/accountBook/service/AccountBookHistoryService.java
@@ -5,13 +5,21 @@ import nbdream.accountBook.domain.AccountBook;
 import nbdream.accountBook.domain.AccountBookCategory;
 import nbdream.accountBook.domain.AccountBookHistory;
 import nbdream.accountBook.domain.TransactionType;
+import nbdream.accountBook.exception.AccountBookHistoryNotFoundException;
 import nbdream.accountBook.exception.AccountBookNotFoundException;
+import nbdream.accountBook.exception.ImageNotFoundException;
 import nbdream.accountBook.repository.AccountBookHistoryRepository;
 import nbdream.accountBook.repository.AccountBookRepository;
 import nbdream.accountBook.service.dto.PostAccountBookReqDto;
+import nbdream.accountBook.service.dto.PutAccountBookReqDto;
 import nbdream.common.advice.response.ApiResponse;
+import nbdream.image.domain.Image;
 import nbdream.image.repository.ImageRepository;
+import nbdream.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,23 +27,65 @@ public class AccountBookHistoryService {
 
     private final AccountBookRepository accountBookRepository;
     private final AccountBookHistoryRepository accountBookHistoryRepository;
+    private final MemberRepository memberRepository;
     private final ImageRepository imageRepository;
 
-
-    //장부 작성
-    public ApiResponse<Void> writeAccountBookHistory(PostAccountBookReqDto reqDto, Long memberId) {
+    //장부 내역 작성
+    @Transactional
+    public ApiResponse<Void> writeAccountBookHistory(PostAccountBookReqDto request, Long memberId) {
         AccountBook accountBook = accountBookRepository.findByMemberId(memberId)
                 .orElseThrow(AccountBookNotFoundException::new);
 
         AccountBookHistory accountBookHistory = AccountBookHistory.builder()
                 .accountBook(accountBook)
-                .accountBookCategory(AccountBookCategory.fromValue(reqDto.getCategory()))
-                .transactionType(reqDto.getExpense() == null ? TransactionType.REVENUE : TransactionType.EXPENSE)
-                .amount(reqDto.getExpense() == null ? reqDto.getRevenue() : reqDto.getExpense())
-                .content(reqDto.getTitle())
-                .dateTime(reqDto.getParsedRegisterDateTime())
+                .accountBookCategory(AccountBookCategory.fromValue(request.getCategory()))
+                .transactionType(TransactionType.fromValue(request.getTransactionType()))
+                .amount(request.getAmount())
+                .content(request.getTitle())
+                .dateTime(request.getParsedRegisterDateTime())
                 .build();
         accountBookHistoryRepository.save(accountBookHistory);
+
+        //이미지를 등록했다면 targetId 업데이트
+        if(request.getImageUrls() != null){
+            List<String> imageUrlList = request.getImageUrls();
+            updateImageTargetId(imageUrlList, accountBookHistory);
+        }
+
         return ApiResponse.ok();
+    }
+
+    //장부 내역 수정
+    @Transactional
+    public ApiResponse<Void> updateAccountBookHistory(PutAccountBookReqDto request, Long accountBookHistoryId) {
+        AccountBookHistory accountBookHistory = accountBookHistoryRepository.findById(accountBookHistoryId)
+                .orElseThrow(AccountBookHistoryNotFoundException::new);
+
+        //이미지를 등록했다면 targetId 업데이트
+        if(request.getImageUrls() != null){
+            List<String> imageUrlList = request.getImageUrls();
+            updateImageTargetId(imageUrlList, accountBookHistory);
+        }
+
+        accountBookHistory.update(
+            accountBookHistory.getAccountBook(),
+            AccountBookCategory.fromValue(request.getCategory()),
+            TransactionType.fromValue(request.getTransactionType()),
+            request.getAmount(),
+            request.getTitle(),
+            request.getParsedRegisterDateTime()
+        );
+
+        accountBookHistoryRepository.save(accountBookHistory);
+        return ApiResponse.ok();
+    }
+
+    @Transactional
+    public void updateImageTargetId(List<String> imageUrlList, AccountBookHistory accountBookHistory){
+        for(String url : imageUrlList){
+            Image image = imageRepository.findByImageUrl(url).orElseThrow(ImageNotFoundException::new);
+            image.update(accountBookHistory.getId());
+            imageRepository.save(image);
+        }
     }
 }

--- a/src/main/java/nbdream/accountBook/service/AccountBookService.java
+++ b/src/main/java/nbdream/accountBook/service/AccountBookService.java
@@ -12,6 +12,8 @@ import nbdream.accountBook.repository.specifications.AccountBookHistorySpecifica
 import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
 import nbdream.accountBook.service.dto.GetAccountBookListResDto;
 import nbdream.accountBook.service.dto.GetAccountBookResDto;
+import nbdream.image.domain.Image;
+import nbdream.image.repository.ImageRepository;
 import nbdream.member.domain.Member;
 import nbdream.member.exception.MemberNotFoundException;
 import nbdream.member.repository.MemberRepository;
@@ -31,6 +33,7 @@ public class AccountBookService {
     private final AccountBookRepository accountBookRepository;
     private final MemberRepository memberRepository;
     private final AccountBookHistoryRepository accountBookHistoryRepository;
+    private final ImageRepository imageRepository;
 
     private static final int PAGE_SIZE = 3;
 
@@ -86,7 +89,13 @@ public class AccountBookService {
 
     // 내역을 DTO로 변환
     private GetAccountBookResDto convertToDto(AccountBookHistory history) {
-        // 예시로 변환 로직 추가
+        List<Image> imgList = imageRepository.findAllByTargetId(history.getId());
+
+        String imgUrl = imgList.stream()
+                .findFirst()
+                .map(Image::getStoredPath)
+                .orElse(null);
+
         return GetAccountBookResDto.builder()
                 .id(history.getId().toString())
                 .title(history.getContent())
@@ -97,6 +106,8 @@ public class AccountBookService {
                 .dayName(history.getKoreanDayOfWeek())
                 .expense(history.getTransactionType() == TransactionType.EXPENSE ? (long) history.getAmount() : null)
                 .revenue(history.getTransactionType() == TransactionType.REVENUE ? (long) history.getAmount() : null)
+                .thumbnail(imgUrl)
+                .imageSize(imgList.size())
                 .build();
     }
 

--- a/src/main/java/nbdream/accountBook/service/AccountBookService.java
+++ b/src/main/java/nbdream/accountBook/service/AccountBookService.java
@@ -90,10 +90,9 @@ public class AccountBookService {
     // 내역을 DTO로 변환
     private GetAccountBookResDto convertToDto(AccountBookHistory history) {
         List<Image> imgList = imageRepository.findAllByTargetId(history.getId());
-
         String imgUrl = imgList.stream()
                 .findFirst()
-                .map(Image::getStoredPath)
+                .map(Image::getImageUrl)
                 .orElse(null);
 
         return GetAccountBookResDto.builder()

--- a/src/main/java/nbdream/accountBook/service/AccountBookService.java
+++ b/src/main/java/nbdream/accountBook/service/AccountBookService.java
@@ -2,63 +2,106 @@ package nbdream.accountBook.service;
 
 import lombok.RequiredArgsConstructor;
 import nbdream.accountBook.domain.AccountBook;
+import nbdream.accountBook.domain.AccountBookCategory;
 import nbdream.accountBook.domain.AccountBookHistory;
+import nbdream.accountBook.domain.TransactionType;
 import nbdream.accountBook.exception.CategoryNotFoundException;
+import nbdream.accountBook.repository.AccountBookHistoryRepository;
 import nbdream.accountBook.repository.AccountBookRepository;
+import nbdream.accountBook.repository.specifications.AccountBookHistorySpecifications;
 import nbdream.accountBook.service.dto.GetAccountBookListReqDto;
 import nbdream.accountBook.service.dto.GetAccountBookListResDto;
 import nbdream.accountBook.service.dto.GetAccountBookResDto;
 import nbdream.member.domain.Member;
 import nbdream.member.exception.MemberNotFoundException;
 import nbdream.member.repository.MemberRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class AccountBookService {
 
-    private final AccountBookHistoryService accountBookHistoryService;
     private final AccountBookRepository accountBookRepository;
     private final MemberRepository memberRepository;
+    private final AccountBookHistoryRepository accountBookHistoryRepository;
+
+    private static final int PAGE_SIZE = 3;
 
     // 장부 조회에 필요한 리스트 가져오는 메서드
     public GetAccountBookListResDto getMyAccountBookList(GetAccountBookListReqDto reqDto, Long memberId) {
-        List<String> categories = getCategoryList();
         AccountBook accountBook = accountBookRepository.findByMemberId(memberId)
                 .orElseGet(() -> createNewAccountBook(memberId));
-        List<AccountBookHistory> accountBookHistoryList = accountBookHistoryService.getMyAccountBookHistoryList(reqDto, accountBook.getMember().getId());
+        List<String> categories = getCategoryList();
+
+        Pageable pageable = PageRequest.of(reqDto.getPage(), PAGE_SIZE);
+        Specification<AccountBookHistory> spec = AccountBookHistorySpecifications.withFilters(reqDto, memberId);
+        Page<AccountBookHistory> accountBookHistoryPage = accountBookHistoryRepository.findAll(spec, pageable);
+
+        List<AccountBookHistory> accountBookHistoryList = accountBookHistoryPage.getContent();
 
         Long totalRevenue = accountBook.getTotalRevenue(accountBookHistoryList);
         Long totalExpense = accountBook.getTotalExpense(accountBookHistoryList);
         Long totalCost = totalRevenue + totalExpense;
 
-        List<GetAccountBookResDto> items = accountBookHistoryService.convertToDtoList(accountBookHistoryList);
-        return buildAccountBookListResDto(categories, items, totalRevenue, totalExpense, totalCost);
-    }
-
-    // 카테고리 목록 조회 메서드
-    private List<String> getCategoryList() {
-        List<String> categories = accountBookHistoryService.getCategoryList();
-        if (categories == null || categories.isEmpty()) {
-            throw new CategoryNotFoundException();
-        }
-        return categories;
+        List<GetAccountBookResDto> items = convertToDtoList(accountBookHistoryList);
+        return createAccountBookListResDto(categories, items, totalRevenue, totalExpense, totalCost);
     }
 
     // 장부 생성
     private AccountBook createNewAccountBook(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException());
+                .orElseThrow(MemberNotFoundException::new);
         AccountBook accountBook = AccountBook.builder()
                 .member(member)
                 .build();
         return accountBookRepository.save(accountBook);
     }
 
+    // 카테고리 목록 조회 메서드
+    private List<String> getCategoryList() {
+        List<String> categories = List.of(AccountBookCategory.values())
+                .stream()
+                .map(AccountBookCategory::getValue)
+                .collect(Collectors.toList());
+
+        if (categories == null || categories.isEmpty()) {
+            throw new CategoryNotFoundException();
+        }
+        return categories;
+    }
+
+    // 내역 리스트를 DTO로 변환
+    private List<GetAccountBookResDto> convertToDtoList(List<AccountBookHistory> historyList) {
+        return historyList.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    // 내역을 DTO로 변환
+    private GetAccountBookResDto convertToDto(AccountBookHistory history) {
+        // 예시로 변환 로직 추가
+        return GetAccountBookResDto.builder()
+                .id(history.getId().toString())
+                .title(history.getContent())
+                .category(history.getAccountBookCategory().getValue())
+                .year(history.getDateTime().getYear())
+                .month(history.getDateTime().getMonthValue())
+                .day(history.getDateTime().getDayOfMonth())
+                .dayName(history.getKoreanDayOfWeek())
+                .expense(history.getTransactionType() == TransactionType.EXPENSE ? (long) history.getAmount() : null)
+                .revenue(history.getTransactionType() == TransactionType.REVENUE ? (long) history.getAmount() : null)
+                .build();
+    }
+
     // resDto 생성
-    private GetAccountBookListResDto buildAccountBookListResDto(List<String> categories, List<GetAccountBookResDto> items,
+    private GetAccountBookListResDto createAccountBookListResDto(List<String> categories, List<GetAccountBookResDto> items,
                                                                 Long totalRevenue, Long totalExpense, Long totalCost) {
         return GetAccountBookListResDto.builder()
                 .categories(categories)
@@ -68,4 +111,5 @@ public class AccountBookService {
                 .totalCost(totalCost)
                 .build();
     }
+
 }

--- a/src/main/java/nbdream/accountBook/service/AccountBookService.java
+++ b/src/main/java/nbdream/accountBook/service/AccountBookService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import nbdream.accountBook.domain.AccountBook;
 import nbdream.accountBook.domain.AccountBookCategory;
 import nbdream.accountBook.domain.AccountBookHistory;
-import nbdream.accountBook.domain.TransactionType;
 import nbdream.accountBook.exception.CategoryNotFoundException;
 import nbdream.accountBook.repository.AccountBookHistoryRepository;
 import nbdream.accountBook.repository.AccountBookRepository;
@@ -38,15 +37,14 @@ public class AccountBookService {
     private static final int PAGE_SIZE = 3;
 
     // 장부 조회에 필요한 리스트 가져오는 메서드
-    public GetAccountBookListResDto getMyAccountBookList(GetAccountBookListReqDto reqDto, Long memberId) {
+    public GetAccountBookListResDto getMyAccountBookList(GetAccountBookListReqDto request, Long memberId) {
         AccountBook accountBook = accountBookRepository.findByMemberId(memberId)
                 .orElseGet(() -> createNewAccountBook(memberId));
         List<String> categories = getCategoryList();
 
-        Pageable pageable = PageRequest.of(reqDto.getPage(), PAGE_SIZE);
-        Specification<AccountBookHistory> spec = AccountBookHistorySpecifications.withFilters(reqDto, memberId);
+        Pageable pageable = PageRequest.of(request.getPage(), PAGE_SIZE);
+        Specification<AccountBookHistory> spec = AccountBookHistorySpecifications.withFilters(request, memberId);
         Page<AccountBookHistory> accountBookHistoryPage = accountBookHistoryRepository.findAll(spec, pageable);
-
         List<AccountBookHistory> accountBookHistoryList = accountBookHistoryPage.getContent();
 
         Long totalRevenue = accountBook.getTotalRevenue(accountBookHistoryList);
@@ -103,8 +101,8 @@ public class AccountBookService {
                 .month(history.getDateTime().getMonthValue())
                 .day(history.getDateTime().getDayOfMonth())
                 .dayName(history.getKoreanDayOfWeek())
-                .expense(history.getTransactionType() == TransactionType.EXPENSE ? (long) history.getAmount() : null)
-                .revenue(history.getTransactionType() == TransactionType.REVENUE ? (long) history.getAmount() : null)
+                .transactionType(history.getTransactionType().getValue())
+                .amount(history.getAmount())
                 .thumbnail(imgUrl)
                 .imageSize(imgList.size())
                 .build();

--- a/src/main/java/nbdream/accountBook/service/dto/GetAccountBookDetailResDto.java
+++ b/src/main/java/nbdream/accountBook/service/dto/GetAccountBookDetailResDto.java
@@ -1,0 +1,27 @@
+package nbdream.accountBook.service.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetAccountBookDetailResDto {
+
+    @NotNull
+    private String id;
+    private String title;
+    private String category;
+    private String transactionType;
+    private Long amount;
+    private String registerDateTime;
+    private List<String> imageUrls;
+
+}

--- a/src/main/java/nbdream/accountBook/service/dto/GetAccountBookListReqDto.java
+++ b/src/main/java/nbdream/accountBook/service/dto/GetAccountBookListReqDto.java
@@ -22,7 +22,7 @@ public class GetAccountBookListReqDto {
     private String start;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private String end;
-    private String cost;
+    private String transactionType;
 
     private AccountBookCategory categoryEnum;
     private TransactionType transactionTypeEnum;

--- a/src/main/java/nbdream/accountBook/service/dto/GetAccountBookListReqDto.java
+++ b/src/main/java/nbdream/accountBook/service/dto/GetAccountBookListReqDto.java
@@ -15,7 +15,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Builder
 public class GetAccountBookListReqDto {
 
-    private Integer page = 0;
+    private Integer page;
     private String category;
     private String sort;
     @DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/nbdream/accountBook/service/dto/GetAccountBookResDto.java
+++ b/src/main/java/nbdream/accountBook/service/dto/GetAccountBookResDto.java
@@ -17,8 +17,8 @@ public class GetAccountBookResDto {
     private int month;
     private int day;
     private String dayName;
-    private Long revenue;
-    private Long expense;
+    private String transactionType;
+    private Long amount;
     private String thumbnail;
     private int imageSize;
 

--- a/src/main/java/nbdream/accountBook/service/dto/PostAccountBookReqDto.java
+++ b/src/main/java/nbdream/accountBook/service/dto/PostAccountBookReqDto.java
@@ -1,0 +1,34 @@
+package nbdream.accountBook.service.dto;
+
+import lombok.*;
+import nbdream.accountBook.exception.InvalidDateFormatException;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class PostAccountBookReqDto {
+
+    private Long revenue;
+    private Long expense;
+    private String category;
+    private String title;
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+    private String registerDateTime;
+
+    public LocalDateTime getParsedRegisterDateTime() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        try {
+            return LocalDateTime.parse(registerDateTime, formatter);
+        } catch (DateTimeParseException e) {
+            throw new InvalidDateFormatException();
+        }
+    }
+}

--- a/src/main/java/nbdream/accountBook/service/dto/PutAccountBookReqDto.java
+++ b/src/main/java/nbdream/accountBook/service/dto/PutAccountBookReqDto.java
@@ -4,7 +4,6 @@ import lombok.*;
 import nbdream.accountBook.exception.InvalidDateFormatException;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -15,14 +14,15 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @ToString
-public class PostAccountBookReqDto {
+public class PutAccountBookReqDto {
 
+    private String id;
     private String transactionType;
     private Long amount;
     private String category;
     private String title;
     private String registerDateTime;
-    List<String> imageUrls;
+    private List<String> imageUrls;
 
     public LocalDateTime getParsedRegisterDateTime() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");

--- a/src/main/java/nbdream/image/domain/Image.java
+++ b/src/main/java/nbdream/image/domain/Image.java
@@ -27,9 +27,6 @@ public class Image extends BaseEntity {
         this.imageUrl = imageUrl;
     }
 
-    public void update(final Long targetId){
-        this.targetId = targetId;
-    }
     public void delete() {
         this.expired();
     }

--- a/src/main/java/nbdream/image/domain/Image.java
+++ b/src/main/java/nbdream/image/domain/Image.java
@@ -4,9 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import nbdream.common.entity.BaseEntity;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -27,5 +25,9 @@ public class Image extends BaseEntity {
     public Image(final Long targetId, final String imageUrl) {
         this.targetId = targetId;
         this.imageUrl = imageUrl;
+    }
+
+    public void update(final Long targetId){
+        this.targetId = targetId;
     }
 }

--- a/src/main/java/nbdream/image/repository/ImageRepository.java
+++ b/src/main/java/nbdream/image/repository/ImageRepository.java
@@ -4,7 +4,10 @@ import nbdream.image.domain.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findAllByTargetId(Long id);
+
+    Optional<Image> findByImageUrl(String s);
 }

--- a/src/main/java/nbdream/member/exception/MemberNotFoundException.java
+++ b/src/main/java/nbdream/member/exception/MemberNotFoundException.java
@@ -1,8 +1,8 @@
 package nbdream.member.exception;
 
-import nbdream.common.exception.NotFoundException;
+import nbdream.common.exception.UnauthorizedException;
 
-public class MemberNotFoundException extends NotFoundException {
+public class MemberNotFoundException extends UnauthorizedException {
     public MemberNotFoundException() {
         super("유저 정보를 찾을 수 없습니다.");
     }


### PR DESCRIPTION
## Issue
- #25 
- #27 
- #34 
- #35 
## Overview



## 참고(optional)
- #14
- Refactor : 서비스와 서비스간의 의존성 주입 제거
- Refactor : ResponseDto에 썸네일url, 이미지 갯수 정보 추가
- Refactor : Dto의 필드명 변경 (revenue, expense) ->(transactionType, amount)