### PR TITLE
Fix : 토양 검정 OpenAPI 로직 변경, 카카오 주소 찾기 API 구현

### DIFF
--- a/src/main/java/nbdream/common/config/AsyncConfig.java
+++ b/src/main/java/nbdream/common/config/AsyncConfig.java
@@ -1,0 +1,34 @@
+package nbdream.common.config;
+
+import nbdream.farm.exception.AsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("Async-Executor-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler(){
+        return new AsyncExceptionHandler();
+    }
+}

--- a/src/main/java/nbdream/farm/controller/LandElementsController.java
+++ b/src/main/java/nbdream/farm/controller/LandElementsController.java
@@ -6,12 +6,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import nbdream.auth.config.AuthenticatedMemberId;
 import nbdream.common.advice.response.ApiResponse;
+import nbdream.farm.domain.Farm;
+import nbdream.farm.repository.FarmRepository;
 import nbdream.farm.service.GeminiService;
 import nbdream.farm.service.LandElementsService;
-import nbdream.farm.service.dto.LandElements.GetLandElementResDto;
+import nbdream.farm.service.dto.LandElements.soilData.GetLandElementResDto;
 import nbdream.farm.service.dto.gemini.PostAiChatReqDto;
 import nbdream.farm.service.dto.gemini.PostAiChatResDto;
 import org.springframework.web.bind.annotation.*;
+
 
 
 @RestController
@@ -21,13 +24,14 @@ import org.springframework.web.bind.annotation.*;
 public class LandElementsController {
     private final LandElementsService landElementsService;
     private final GeminiService geminiService;
+    private final FarmRepository farmRepository;
 
-    @Operation(summary = "토지 성분 분석", description = "테스트 시 농장에 주소가 등록되어 있어야 함")
+
+    @Operation(summary = "토지 성분 분석 (법정동코드)", description = "테스트 시 농장에 법정동 코드, 위도, 경도가 등록되어 있어야 함. ")
     @GetMapping("/land-elements")
-    public ApiResponse<GetLandElementResDto> getLandElements(@Parameter(hidden = true) @AuthenticatedMemberId Long memberId){
-        return ApiResponse.ok(landElementsService.getLandElements(memberId));
+    public ApiResponse<GetLandElementResDto> getLandElementsByBjd(@Parameter(hidden = true) @AuthenticatedMemberId Long memberId) {
+        return ApiResponse.ok(landElementsService.getLandElementsByBjd(memberId));
     }
-
 
     @Operation(summary = "AI 채팅", description = "테스트 시 토지 성분 분석이 먼저 되어야 함")
     @PostMapping("/ai")
@@ -36,4 +40,13 @@ public class LandElementsController {
         PostAiChatResDto response = new PostAiChatResDto(geminiService.getContents(reqDto, memberId));
         return ApiResponse.ok(response);
     }
+
+
 }
+
+//    @Operation(summary = "토지 성분 분석", description = "테스트 시 농장에 주소가 등록되어 있어야 함. PNU 코드 이용")
+//    @GetMapping("/land-elements")
+//    public ApiResponse<GetLandElementResDto> getLandElements(@Parameter(hidden = true) @AuthenticatedMemberId Long memberId){
+//        return ApiResponse.ok(landElementsService.getLandElements(memberId));
+//    }
+

--- a/src/main/java/nbdream/farm/domain/Location.java
+++ b/src/main/java/nbdream/farm/domain/Location.java
@@ -14,7 +14,7 @@ public class Location {
 
     private String address;
 
-    private String pnuCode;
+    private String bjdCode;
 
     private double latitude;
 
@@ -26,7 +26,7 @@ public class Location {
 
     public Location() {
         this.address = EMPTY;
-        this.pnuCode = EMPTY;
+        this.bjdCode = EMPTY;
     }
 
     public void update(final String address, final double latitude, final double longitude) {

--- a/src/main/java/nbdream/farm/exception/AsyncExceptionHandler.java
+++ b/src/main/java/nbdream/farm/exception/AsyncExceptionHandler.java
@@ -1,0 +1,14 @@
+package nbdream.farm.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error( ex.getMessage(), ex);
+    }
+}

--- a/src/main/java/nbdream/farm/exception/ClosestSoilDataInternalServerErrorException.java
+++ b/src/main/java/nbdream/farm/exception/ClosestSoilDataInternalServerErrorException.java
@@ -1,0 +1,9 @@
+package nbdream.farm.exception;
+
+import nbdream.common.exception.InternalServerErrorException;
+
+public class ClosestSoilDataInternalServerErrorException extends InternalServerErrorException {
+    public ClosestSoilDataInternalServerErrorException() {
+        super("가장 가까운 토양정보를 매칭하는데 실패하였습니다.");
+    }
+}

--- a/src/main/java/nbdream/farm/exception/CoordinatesNotFoundException.java
+++ b/src/main/java/nbdream/farm/exception/CoordinatesNotFoundException.java
@@ -1,0 +1,9 @@
+package nbdream.farm.exception;
+
+import nbdream.common.exception.NotFoundException;
+
+public class CoordinatesNotFoundException extends NotFoundException {
+    public CoordinatesNotFoundException() {
+        super("유저의 위도, 경도를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/nbdream/farm/exception/KakaoLocalServiceErrorException.java
+++ b/src/main/java/nbdream/farm/exception/KakaoLocalServiceErrorException.java
@@ -1,0 +1,9 @@
+package nbdream.farm.exception;
+
+import nbdream.common.exception.InternalServerErrorException;
+
+public class KakaoLocalServiceErrorException extends InternalServerErrorException {
+    public KakaoLocalServiceErrorException() {
+        super("카카오 위도 경도 변환을 실패했습니다.");
+    }
+}

--- a/src/main/java/nbdream/farm/service/GeminiService.java
+++ b/src/main/java/nbdream/farm/service/GeminiService.java
@@ -6,6 +6,7 @@ import nbdream.accountBook.exception.CategoryNotFoundException;
 import nbdream.farm.domain.Crop;
 import nbdream.farm.domain.Farm;
 import nbdream.farm.domain.LandElements;
+import nbdream.farm.exception.CropNotFoundException;
 import nbdream.farm.exception.FetchApiInternalServerErrorException;
 import nbdream.farm.exception.LandElementsNotFoundException;
 import nbdream.farm.repository.CropRepository;
@@ -45,7 +46,7 @@ public class GeminiService {
     public String getContents(PostAiChatReqDto reqDto, Long memberId) {
         List<Crop> cropList = cropRepository.findAll();
         if(cropList == null || cropList.isEmpty()){
-            throw new CategoryNotFoundException();
+            throw new CropNotFoundException();
         }
         LandElements landElements = getLandElementsByMemberId(memberId)
                 .orElseThrow(LandElementsNotFoundException::new);
@@ -78,9 +79,11 @@ public class GeminiService {
     private boolean isValid(String question, List<Crop> cropList) {
         if(question.equals("1")){
             return true;
-        }else if(question.equals("2")){
-            return false;
-        }else if(isCrop(question, cropList)){
+        }
+//        else if(question.equals("2")){
+//            return false;
+//        }
+        else if(isCrop(question, cropList)){
             return true;
         }else{
             return false;
@@ -92,30 +95,33 @@ public class GeminiService {
 
         if(question.equals("1")){
             return "작물에 관해서 토지 성분 분석 결과가 궁굼해요. 토양 정보 : " + landElements.toStringForAIChat();
-        }else if(question.equals("2")){
-            return "어떤 작물이 궁굼하신가요? \n" +
-                    listToString(cropList) + "\n" +
-                    "(작물 이름만 입력해 주세요)";
-        }else if(isCrop(question, cropList)){
+        }
+//        else if(question.equals("2")){
+//            return "어떤 작물이 궁굼하신가요? \n" +
+//                    listToString(cropList) + "\n" +
+//                    "(작물 이름만 입력해 주세요)";
+//        }
+        else if(isCrop(question, cropList)){
             return "작물인 " + question + "에 대한 토양 적합성이 궁굼해. 토양 정보 : " + landElements.toStringForAIChat();
         }
         else{
-            return "저에게 여쭤보고 싶은게 있으신가요?\n" +
-                    "1. 토지 성분 분석 결과가 궁굼해요\n" +
-                    "2. 작물별 토양 적합성이 궁굼해요\n" +
-                    " (숫자로 입력해 주세요)";
+            return "잘못된 질문 요청입니다.";
+//            return "저에게 여쭤보고 싶은게 있으신가요?\n" +
+//                    "1. 토지 성분 분석 결과가 궁굼해요\n" +
+//                    "2. 작물별 토양 적합성이 궁굼해요\n" +
+//                    " (숫자로 입력해 주세요)";
         }
     }
 
-    public static String listToString(List<Crop> cropList) {
-        String str = "(가능한 작물 종류 : ";
-
-        for(Crop crop : cropList){
-            str += crop.getName() + " ";
-        }
-        str += ")";
-        return str;
-    }
+//    public static String listToString(List<Crop> cropList) {
+//        String str = "(가능한 작물 종류 : ";
+//
+//        for(Crop crop : cropList){
+//            str += crop.getName() + " ";
+//        }
+//        str += ")";
+//        return str;
+//    }
 
     public static boolean isCrop(String question, List<Crop> cropList) {
         for(Crop crop : cropList){

--- a/src/main/java/nbdream/farm/service/KakaoAddressService.java
+++ b/src/main/java/nbdream/farm/service/KakaoAddressService.java
@@ -1,0 +1,56 @@
+package nbdream.farm.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import nbdream.farm.exception.KakaoLocalServiceErrorException;
+import nbdream.farm.service.dto.workSchedule.kakaoResponse.KakaoResponse;
+import nbdream.farm.util.Coordinates;
+import nbdream.farm.util.UrlUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URL;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAddressService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${kakao-local.api.url}")
+    private String kakaoLocalUrl;
+
+    @Value("${kakao-local.api.key}")
+    private String kakaoLocalAPIKey;
+
+
+
+    // 매개변수 : 주소
+    // 리턴 : 위도 경도
+    public Coordinates kakaoAddressSearch(String query) {
+        try{
+            //URI
+            String encodedQuery = UrlUtil.encodeParam(query);
+            StringBuilder urlBuilder = new StringBuilder(kakaoLocalUrl);
+            urlBuilder.append(".json");
+            urlBuilder.append("?query=").append(encodedQuery);
+            URL url = new URL(urlBuilder.toString());
+            //헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK" + " " + kakaoLocalAPIKey);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(url.toURI(), HttpMethod.GET, entity, String.class);
+            KakaoResponse kakaoResponse = objectMapper.readValue(response.getBody(), KakaoResponse.class);
+            return new Coordinates(kakaoResponse.getDocuments().get(0).getY(), kakaoResponse.getDocuments().get(0).getX());
+        } catch (Exception e){
+            throw new KakaoLocalServiceErrorException();
+        }
+    }
+}

--- a/src/main/java/nbdream/farm/service/KakaoAsyncService.java
+++ b/src/main/java/nbdream/farm/service/KakaoAsyncService.java
@@ -1,0 +1,25 @@
+package nbdream.farm.service;
+
+import lombok.RequiredArgsConstructor;
+import nbdream.farm.util.Coordinates;
+import nbdream.farm.exception.KakaoLocalServiceErrorException;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAsyncService {
+
+    private final KakaoAddressService kakaoAddressService;
+
+    @Async("taskExecutor")
+    public CompletableFuture<Coordinates> getCoordinatesAsync(String address) {
+        try {
+            return CompletableFuture.completedFuture(kakaoAddressService.kakaoAddressSearch(address));
+        } catch (Exception e) {
+            throw new KakaoLocalServiceErrorException();
+        }
+    }
+}

--- a/src/main/java/nbdream/farm/service/LandElementsService.java
+++ b/src/main/java/nbdream/farm/service/LandElementsService.java
@@ -1,23 +1,29 @@
 package nbdream.farm.service;
 
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import lombok.RequiredArgsConstructor;
 import nbdream.farm.domain.Farm;
+import nbdream.farm.domain.LandElements;
 import nbdream.farm.exception.*;
 import nbdream.farm.repository.FarmRepository;
-import nbdream.farm.domain.LandElements;
 import nbdream.farm.repository.LandElementsRepository;
-import nbdream.farm.service.dto.LandElements.GetLandElementResDto;
-import nbdream.farm.service.dto.LandElements.Item;
-import nbdream.farm.service.dto.LandElements.SoilDataResponse;
+import nbdream.farm.service.dto.LandElements.soilData.GetLandElementResDto;
+import nbdream.farm.service.dto.LandElements.soilDataList.ItemBjd;
+import nbdream.farm.service.dto.LandElements.soilDataList.SoilDataListResponse;
+import nbdream.farm.util.Coordinates;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-
-import java.net.URL;
-import java.util.List;
-
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static nbdream.farm.util.Coordinates.findNearestLocation;
 
 @Service
 @RequiredArgsConstructor
@@ -25,9 +31,8 @@ public class LandElementsService {
 
     private final FarmRepository farmRepository;
     private final LandElementsRepository landElementsRepository;
-
-    //토양검정
-    private final RestTemplate soilRestTemplate;
+    private final KakaoAsyncService kakaoAsyncService;
+    private final RestTemplate restTemplate;
 
     @Value("${soil.api.url}")
     private String soilApiUrl;
@@ -36,63 +41,92 @@ public class LandElementsService {
     private String soilApiKey;
 
 
-
-    public GetLandElementResDto getLandElements(Long memberId) {
+    //유저의 토양 정보가 있으면 반환, 없으면 저장 후 반환
+    public GetLandElementResDto getLandElementsByBjd(Long memberId) {
         Farm farm = farmRepository.findByMemberId(memberId)
                 .orElseThrow(FarmNotFoundException::new);
-        if (farm.getLocation() == null || farm.getLocation().getPnuCode() == null || farm.getLocation().getPnuCode().isEmpty()) {
-            throw new PnuNotFoundException();
+        if (farm.getLocation() == null || farm.getLocation().getBjdCode() == null || farm.getLocation().getBjdCode().isBlank() ||
+                farm.getLocation().getLatitude() == 0 || farm.getLocation().getLongitude() == 0) {
+            throw new CoordinatesNotFoundException();
         }
 
+        LandElements landElements = getOrFetchLandElements(farm);
+
+        return new GetLandElementResDto().updateResDto(landElements);
+    }
+
+    private LandElements getOrFetchLandElements(Farm farm) {
         LandElements landElements = farm.getLandElements();
-        GetLandElementResDto response = new GetLandElementResDto();
-        // 토양 정보가 없으면 받아와서 저장
         if (landElements == null) {
-            landElements = fetchSoilDataFromApi(farm.getLocation().getPnuCode());
+            landElements = getNewLandElementsFromOpenApi(farm);
             landElementsRepository.save(landElements);
             farm.updateLandElements(landElements);
             farmRepository.save(farm);
         }
-        response.updateResDto(landElements);
-        return response;
-    }
-
-    //농장 주소 수정시 실행되어야 할 메서드
-    public void fetchLandElements(Farm farm){
-        LandElements landElements = landElementsRepository.findById(farm.getLandElements().getId())
-                .orElseThrow(LandElementsNotFoundException::new);
-        LandElements newLandElements = fetchSoilDataFromApi(farm.getLocation().getPnuCode());
-        landElements.update(newLandElements);
-        landElementsRepository.save(landElements);
+        return landElements;
     }
 
 
+    // 유저의 법정동 코드로 토양 리스트를 받아와서, 가장 가까운 위치의 토양 성분을 반환
+    private LandElements getNewLandElementsFromOpenApi(Farm farm) {
+        List<ItemBjd> soilDataList = fetchSoilDataFromApiByBjd(farm.getLocation().getBjdCode(), "List");
+        //유저와 토양 리스트의 위치 비교
+        Coordinates userCoordinates = new Coordinates(farm.getLocation().getLatitude(), farm.getLocation().getLongitude());
+        Map<Integer, Coordinates> coordinatesMap = getCoordinatesByAddressFromKakao(soilDataList);
+        int num = findNearestLocation(userCoordinates, coordinatesMap);
 
-    //토양검정
-    private LandElements fetchSoilDataFromApi(String pnuCode) {
+        ItemBjd closestData = soilDataList.stream()
+                .filter(soilData -> num == soilData.getNo())
+                .findFirst().orElseThrow(ClosestSoilDataInternalServerErrorException::new);
+        return new LandElements(
+                closestData.getAcid(),
+                closestData.getVldpha(),
+                closestData.getVldsia(),
+                closestData.getOm(),
+                closestData.getPosifertMg(),
+                closestData.getPosifertK(),
+                closestData.getPosifertCa(),
+                closestData.getSelc()
+        );
+    }
+
+    //토양검정(BJD) Open API 요청
+    private List<ItemBjd> fetchSoilDataFromApiByBjd(String bjdCode, String path) {
         try {
             StringBuilder urlBuilder = new StringBuilder(soilApiUrl);
+            urlBuilder.append(path);
             urlBuilder.append("?serviceKey" +  "=" + soilApiKey);
-            urlBuilder.append("&PNU_Code"  + "=" + pnuCode);
+            urlBuilder.append("&BJD_Code"  + "=" + bjdCode);
+            urlBuilder.append("&Page_Size"  + "=" + "100");
+            urlBuilder.append("&Page_No"  + "=" + "1");
             URL url = new URL(urlBuilder.toString());
 
-            String xmlResponse = soilRestTemplate.getForObject(url.toURI(), String.class);
-            return parseSoilData(xmlResponse);
+            String xmlResponse = restTemplate.getForObject(url.toURI(), String.class);
+            return removeDuplicates(parseSoilDataList(xmlResponse));
         } catch (Exception e) {
             throw new FetchApiInternalServerErrorException();
         }
     }
 
-    private LandElements parseSoilData(String xmlResponse) {
+    // 중복 제거 (주소가 같으면 최신년도 정보만 남김)
+    private List<ItemBjd> removeDuplicates(List<ItemBjd> soilList) {
+        Map<String, ItemBjd> filteredMap = soilList.stream()
+                .collect(Collectors.toMap(
+                        ItemBjd::getPnuNm,
+                        item -> item,
+                        (existing, replacement) -> existing.getAnyYear() >= replacement.getAnyYear() ? existing : replacement
+                ));
+        return filteredMap.values().stream().collect(Collectors.toList());
+    }
+
+    //파싱(BJD)
+    private List<ItemBjd> parseSoilDataList(String xmlResponse) {
         try{
             XmlMapper xmlMapper = new XmlMapper();
-            SoilDataResponse response = xmlMapper.readValue(xmlResponse, SoilDataResponse.class);
-            List<Item> items = response.getBody().getItems();
-
+            SoilDataListResponse response = xmlMapper.readValue(xmlResponse, SoilDataListResponse.class);
+            List<ItemBjd> items = response.getBody().getItems();
             if(items != null && !(items.isEmpty())){
-                Item item = items.get(0);
-                LandElements landElements = new LandElements(item.getAcid(), item.getVldpha(), item.getVldsia(), item.getOm(), item.getPosifertMg(), item.getPosifertK(), item.getPosifertCa(), item.getSelc());
-                return landElements;
+                return items;
             }
         }catch (Exception e){
             throw new ParsingInternalServerErrorException();
@@ -100,4 +134,91 @@ public class LandElementsService {
         return null;
     }
 
+    // 주소를 위도, 경도값으로 받아오는 카카오API
+    private Map<Integer, Coordinates> getCoordinatesByAddressFromKakao(List<ItemBjd> items) {
+        Map<Integer, String> addressMap = new HashMap<>();
+        Map<Integer, Coordinates> coordinatesMap = new ConcurrentHashMap<>();
+
+        for (ItemBjd item : items) {
+            addressMap.put(item.getNo(), item.getPnuNm());
+        }
+        List<CompletableFuture<Void>> futures = addressMap.entrySet().stream()
+                .map(entry -> kakaoAsyncService.getCoordinatesAsync(entry.getValue())
+                        .thenAccept(coordinates -> {
+                            coordinatesMap.put(entry.getKey(), coordinates);
+                        }))
+                .collect(Collectors.toList());
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        return coordinatesMap;
+    }
+
+
+    //농장 주소 수정시 실행되어야 할 메서드
+    public void updateLandElements(Long memberId){
+        Farm farm = farmRepository.findByMemberId(memberId).orElseThrow(FarmNotFoundException::new);
+        LandElements landElements = landElementsRepository.findById(farm.getLandElements().getId())
+                .orElseThrow(LandElementsNotFoundException::new);
+        LandElements newLandElements = getNewLandElementsFromOpenApi(farm);
+        landElements.update(newLandElements);
+        landElementsRepository.save(landElements);
+    }
+
 }
+
+//
+//
+//    // 요청 : 유저ID(PNU)
+//    // 응답 : 토양정보
+//    public GetLandElementResDto getLandElements(Long memberId) {
+//        Farm farm = farmRepository.findByMemberId(memberId)
+//                .orElseThrow(FarmNotFoundException::new);
+//        if (farm.getLocation() == null || farm.getLocation().getPnuCode() == null || farm.getLocation().getPnuCode().isEmpty()) {
+//            throw new PnuNotFoundException();
+//        }
+//
+//        LandElements landElements = farm.getLandElements();
+//        GetLandElementResDto response = new GetLandElementResDto();
+//        // 토양 정보가 없으면 받아와서 저장
+//        if (landElements == null) {
+//            landElements = fetchSoilDataFromApi(farm.getLocation().getPnuCode());
+//            landElementsRepository.save(landElements);
+//            farm.updateLandElements(landElements);
+//            farmRepository.save(farm);
+//        }
+//        response.updateResDto(landElements);
+//        return response;
+//    }
+//
+//    //토양검정(PNU)
+//    private LandElements fetchSoilDataFromApi(String pnuCode) {
+//        try {
+//            StringBuilder urlBuilder = new StringBuilder(soilApiUrl);
+//            urlBuilder.append("?serviceKey" +  "=" + soilApiKey);
+//            urlBuilder.append("&PNU_Code"  + "=" + pnuCode);
+//            URL url = new URL(urlBuilder.toString());
+//
+//            String xmlResponse = restTemplate.getForObject(url.toURI(), String.class);
+//            return parseSoilData(xmlResponse);
+//        } catch (Exception e) {
+//            throw new FetchApiInternalServerErrorException();
+//        }
+//    }
+//
+//    //파싱(PNU)
+//    private LandElements parseSoilData(String xmlResponse) {
+//        try{
+//            XmlMapper xmlMapper = new XmlMapper();
+//            SoilDataResponse response = xmlMapper.readValue(xmlResponse, SoilDataResponse.class);
+//            List<Item> items = response.getBody().getItems();
+//
+//            if(items != null && !(items.isEmpty())){
+//                Item item = items.get(0);
+//                LandElements landElements = new LandElements(item.getAcid(), item.getVldpha(), item.getVldsia(), item.getOm(), item.getPosifertMg(), item.getPosifertK(), item.getPosifertCa(), item.getSelc());
+//                return landElements;
+//            }
+//        }catch (Exception e){
+//            throw new ParsingInternalServerErrorException();
+//        }
+//        return null;
+//    }
+

--- a/src/main/java/nbdream/farm/service/dto/LandElements/soilData/Body.java
+++ b/src/main/java/nbdream/farm/service/dto/LandElements/soilData/Body.java
@@ -1,4 +1,4 @@
-package nbdream.farm.service.dto.LandElements;
+package nbdream.farm.service.dto.LandElements.soilData;
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;

--- a/src/main/java/nbdream/farm/service/dto/LandElements/soilData/GetLandElementResDto.java
+++ b/src/main/java/nbdream/farm/service/dto/LandElements/soilData/GetLandElementResDto.java
@@ -1,4 +1,4 @@
-package nbdream.farm.service.dto.LandElements;
+package nbdream.farm.service.dto.LandElements.soilData;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,7 +22,7 @@ public class GetLandElementResDto {
     private float selc; // 전기전도도
 
 
-    public void updateResDto(LandElements landElements){
+    public GetLandElementResDto updateResDto(LandElements landElements){
         this.acid = landElements.getAcid();
         this.vldpha = landElements.getVldpha();
         this.vldsia = landElements.getVldsia();
@@ -31,5 +31,6 @@ public class GetLandElementResDto {
         this.posifert_k = landElements.getPosifert_k();
         this.posifert_ca = landElements.getPosifert_ca();
         this.selc = landElements.getSelc();
+        return this;
     }
 }

--- a/src/main/java/nbdream/farm/service/dto/LandElements/soilData/Item.java
+++ b/src/main/java/nbdream/farm/service/dto/LandElements/soilData/Item.java
@@ -1,0 +1,46 @@
+package nbdream.farm.service.dto.LandElements.soilData;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Getter;
+
+@Getter
+public class Item {
+    @JacksonXmlProperty(localName = "PNU_Code")
+    private String pnuCode;
+
+    @JacksonXmlProperty(localName = "Any_Year")
+    private int anyYear;
+
+    @JacksonXmlProperty(localName = "Exam_Day")
+    private String examDay;
+
+    @JacksonXmlProperty(localName = "Exam_Type")
+    private int examType;
+
+    @JacksonXmlProperty(localName = "PNU_Nm")
+    private String pnuNm;
+
+    @JacksonXmlProperty(localName = "ACID")
+    private float acid;
+
+    @JacksonXmlProperty(localName = "VLDPHA")
+    private float vldpha;
+
+    @JacksonXmlProperty(localName = "VLDSIA")
+    private float vldsia;
+
+    @JacksonXmlProperty(localName = "OM")
+    private float om;
+
+    @JacksonXmlProperty(localName = "POSIFERT_MG")
+    private float posifertMg;
+
+    @JacksonXmlProperty(localName = "POSIFERT_K")
+    private float posifertK;
+
+    @JacksonXmlProperty(localName = "POSIFERT_CA")
+    private float posifertCa;
+
+    @JacksonXmlProperty(localName = "SELC")
+    private float selc;
+}

--- a/src/main/java/nbdream/farm/service/dto/LandElements/soilData/SoilDataResponse.java
+++ b/src/main/java/nbdream/farm/service/dto/LandElements/soilData/SoilDataResponse.java
@@ -1,4 +1,4 @@
-package nbdream.farm.service.dto.LandElements;
+package nbdream.farm.service.dto.LandElements.soilData;
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Getter;

--- a/src/main/java/nbdream/farm/service/dto/LandElements/soilDataList/Body.java
+++ b/src/main/java/nbdream/farm/service/dto/LandElements/soilDataList/Body.java
@@ -1,0 +1,23 @@
+package nbdream.farm.service.dto.LandElements.soilDataList;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class Body {
+    @JacksonXmlElementWrapper(localName = "items")
+    @JacksonXmlProperty(localName = "item")
+    public List<ItemBjd> items;
+
+    @JacksonXmlProperty(localName = "Rcdcnt")
+    public int rcdCnt;
+
+    @JacksonXmlProperty(localName = "Page_No")
+    public int pageNo;
+
+    @JacksonXmlProperty(localName = "Total_Count")
+    public int totalCount;
+}

--- a/src/main/java/nbdream/farm/service/dto/LandElements/soilDataList/ItemBjd.java
+++ b/src/main/java/nbdream/farm/service/dto/LandElements/soilDataList/ItemBjd.java
@@ -1,12 +1,17 @@
-package nbdream.farm.service.dto.LandElements;
+package nbdream.farm.service.dto.LandElements.soilDataList;
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
-public class Item {
-    @JacksonXmlProperty(localName = "PNU_Code")
-    private String pnuCode;
+@ToString
+public class ItemBjd {
+    @JacksonXmlProperty(localName = "No")
+    private int no;
+
+    @JacksonXmlProperty(localName = "BJD_Code")
+    private String bjdCode;
 
     @JacksonXmlProperty(localName = "Any_Year")
     private int anyYear;

--- a/src/main/java/nbdream/farm/service/dto/LandElements/soilDataList/SoilDataListResponse.java
+++ b/src/main/java/nbdream/farm/service/dto/LandElements/soilDataList/SoilDataListResponse.java
@@ -1,0 +1,27 @@
+package nbdream.farm.service.dto.LandElements.soilDataList;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Getter;
+
+
+@Getter
+public class SoilDataListResponse {
+    public Script script;
+    public Header header;
+    public Body body;
+}
+
+@Getter
+class Script {
+}
+
+@Getter
+class Header {
+    @JacksonXmlProperty(localName = "Result_Code")
+    public int resultCode;
+
+    @JacksonXmlProperty(localName = "Result_Msg")
+    public String resultMsg;
+}
+
+

--- a/src/main/java/nbdream/farm/service/dto/workSchedule/kakaoResponse/KakaoResponse.java
+++ b/src/main/java/nbdream/farm/service/dto/workSchedule/kakaoResponse/KakaoResponse.java
@@ -1,0 +1,104 @@
+package nbdream.farm.service.dto.workSchedule.kakaoResponse;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class KakaoResponse {
+
+    private List<Document> documents;
+    private Meta meta;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class Document {
+        private Address address;
+        @JsonProperty("address_name")
+        private String addressName;
+        @JsonProperty("address_type")
+        private String addressType;
+        @JsonProperty("road_address")
+        private RoadAddress roadAddress;
+        private double x;
+        private double y;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class Address {
+        @JsonProperty("address_name")
+        private String addressName;
+        @JsonProperty("b_code")
+        private String bCode;
+        @JsonProperty("h_code")
+        private String hCode;
+        @JsonProperty("main_address_no")
+        private String mainAddressNo;
+        @JsonProperty("mountain_yn")
+        private String mountainYn;
+        @JsonProperty("region_1depth_name")
+        private String region1depthName;
+        @JsonProperty("region_2depth_name")
+        private String region2depthName;
+        @JsonProperty("region_3depth_h_name")
+        private String region3depthHName;
+        @JsonProperty("region_3depth_name")
+        private String region3depthName;
+        @JsonProperty("sub_address_no")
+        private String subAddressNo;
+        private String x;
+        private String y;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class RoadAddress {
+        @JsonProperty("address_name")
+        private String addressName;
+        @JsonProperty("building_name")
+        private String buildingName;
+        @JsonProperty("main_building_no")
+        private String mainBuildingNo;
+        @JsonProperty("region_1depth_name")
+        private String region1depthName;
+        @JsonProperty("region_2depth_name")
+        private String region2depthName;
+        @JsonProperty("region_3depth_name")
+        private String region3depthName;
+        @JsonProperty("sub_building_no")
+        private String subBuildingNo;
+        @JsonProperty("underground_yn")
+        private String undergroundYn;
+        @JsonProperty("zone_no")
+        private String zoneNo;
+        private String x;
+        private String y;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class Meta {
+        @JsonProperty("is_end")
+        private boolean isEnd;
+        @JsonProperty("pageable_count")
+        private int pageableCount;
+        @JsonProperty("total_count")
+        private int totalCount;
+    }
+}

--- a/src/main/java/nbdream/farm/util/Coordinates.java
+++ b/src/main/java/nbdream/farm/util/Coordinates.java
@@ -1,0 +1,45 @@
+package nbdream.farm.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Coordinates {
+
+    private double latitude;
+    private double longitude;
+
+    public static int findNearestLocation(Coordinates baseCoordinates, Map<Integer, Coordinates> coordinatesMap) {
+        double minDistance = Double.MAX_VALUE;
+        int nearestNo = -1;
+
+        for (Map.Entry<Integer, Coordinates> entry : coordinatesMap.entrySet()) {
+            double distance = haversine(baseCoordinates, entry.getValue());
+            if (distance < minDistance) {
+                minDistance = distance;
+                nearestNo = entry.getKey();
+            }
+        }
+
+        return nearestNo;
+    }
+
+    private static double haversine(Coordinates coord1, Coordinates coord2) {
+        final int R = 6371; // Radius of the earth in km
+        double latDistance = Math.toRadians(coord2.getLatitude() - coord1.getLatitude());
+        double lonDistance = Math.toRadians(coord2.getLongitude() - coord1.getLongitude());
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(coord1.getLatitude())) * Math.cos(Math.toRadians(coord2.getLatitude()))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        double distance = R * c; // convert to kilometers
+        return distance;
+    }
+}

--- a/src/main/java/nbdream/farm/util/UrlUtil.java
+++ b/src/main/java/nbdream/farm/util/UrlUtil.java
@@ -1,0 +1,17 @@
+package nbdream.farm.util;
+
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+public class UrlUtil {
+
+    //Uri에 한글이 들어갈 경우 인코딩 해주는 메서드
+    public static String encodeParam(String param) {
+        try {
+            return URLEncoder.encode(param, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,3 +68,8 @@ farm-work:
   api:
     url: http://api.nongsaro.go.kr/service/farmWorkingPlanNew
     key: ${FARM_WORK_API_KEY}
+
+kakao-local:
+  api:
+    url: https://dapi.kakao.com/v2/local/search/address
+    key: ${KAKAO_LOCAL_API_KEY}


### PR DESCRIPTION
기존
- PNU코드를 이용해서 OpenAPI 서비스 이용

변경
- 법정동 코드를 이용해서 OpenApi 서비스 이용하도록 변경
- Farm 엔티티의 pnuCode를 bjdCode로 변경

추가
- 카카오 주소 찾기 API (주소를 요청받아서 위도,경도를 응답) 구현
- 토양 검정 리스트중에서 유저와 가장 가까운 토양 데이터를 찾는 로직 구현

## Issue
- #58 


## Overview



## 참고(optional)
