### PR TITLE
Fix: 프로필 수정, 회원 탈퇴 시 발생하는 오류 수정

### DIFF
--- a/src/main/java/nbdream/bulletin/controller/BulletinController.java
+++ b/src/main/java/nbdream/bulletin/controller/BulletinController.java
@@ -43,9 +43,8 @@ public class BulletinController {
 
     @Operation(summary = "북마크")
     @PostMapping("/{bulletin-id}/bookmark")
-    public ApiResponse<Void> bookmarkBulletin(@Parameter(hidden = true) @AuthenticatedMemberId final Long memberId,
+    public ApiResponse<Integer> bookmarkBulletin(@Parameter(hidden = true) @AuthenticatedMemberId final Long memberId,
                                             @PathVariable("bulletin-id") final Long bulletinId) {
-        bulletinService.bookmark(memberId, bulletinId);
-        return ApiResponse.ok();
+        return ApiResponse.ok(bulletinService.bookmark(memberId, bulletinId));
     }
 }

--- a/src/main/java/nbdream/bulletin/domain/BookmarkStatus.java
+++ b/src/main/java/nbdream/bulletin/domain/BookmarkStatus.java
@@ -1,0 +1,15 @@
+package nbdream.bulletin.domain;
+
+public enum BookmarkStatus {
+    ON(1), OFF(0);
+
+    private final int code;
+
+    BookmarkStatus(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/src/main/java/nbdream/bulletin/repository/BulletinRepository.java
+++ b/src/main/java/nbdream/bulletin/repository/BulletinRepository.java
@@ -1,7 +1,6 @@
 package nbdream.bulletin.repository;
 
 import nbdream.bulletin.domain.Bulletin;
-import nbdream.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/nbdream/bulletin/service/BulletinService.java
+++ b/src/main/java/nbdream/bulletin/service/BulletinService.java
@@ -2,6 +2,7 @@ package nbdream.bulletin.service;
 
 import lombok.RequiredArgsConstructor;
 import nbdream.bulletin.domain.Bookmark;
+import nbdream.bulletin.domain.BookmarkStatus;
 import nbdream.bulletin.domain.Bulletin;
 import nbdream.bulletin.domain.BulletinCategory;
 import nbdream.bulletin.dto.request.BulletinReqDto;
@@ -60,7 +61,7 @@ public class BulletinService {
         bulletin.delete(memberId);
     }
 
-    public void bookmark(final Long memberId, final Long bulletinId) {
+    public int bookmark(final Long memberId, final Long bulletinId) {
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         Bulletin bulletin = bulletinRepository.findById(bulletinId).orElseThrow(() -> new BulletinNotFoundException());
 
@@ -69,8 +70,11 @@ public class BulletinService {
         if (bookmark.isEmpty()) {
             bookmarkRepository.save(new Bookmark(member, bulletin));
             bulletin.plusBookmarkedCount();
+            return BookmarkStatus.ON.getCode();
         }
-        if (bookmark.isPresent()) handleExistingBookmark(bulletin, bookmark.get());
+
+        handleExistingBookmark(bulletin, bookmark.get());
+        return BookmarkStatus.OFF.getCode();
     }
 
     private void handleExistingBookmark(Bulletin bulletin, Bookmark bookmark) {

--- a/src/main/java/nbdream/farm/domain/Farm.java
+++ b/src/main/java/nbdream/farm/domain/Farm.java
@@ -7,9 +7,6 @@ import lombok.NoArgsConstructor;
 import nbdream.common.entity.BaseEntity;
 import nbdream.member.domain.Member;
 
-import static nbdream.farm.domain.Location.EMPTY;
-
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,8 +20,6 @@ public class Farm extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    private String name;
-
     @Embedded
     private Location location;
 
@@ -33,7 +28,6 @@ public class Farm extends BaseEntity {
     private LandElements landElements;
 
     public Farm(final Member member) {
-        this.name = EMPTY;
         this.location = new Location();
         this.landElements = new LandElements();
         this.member = member;

--- a/src/main/java/nbdream/farm/service/KakaoAddressService.java
+++ b/src/main/java/nbdream/farm/service/KakaoAddressService.java
@@ -29,8 +29,6 @@ public class KakaoAddressService {
     @Value("${kakao-local.api.key}")
     private String kakaoLocalAPIKey;
 
-
-
     // 매개변수 : 주소
     // 리턴 : 위도 경도
     public Coordinates kakaoAddressSearch(String query) {
@@ -48,6 +46,9 @@ public class KakaoAddressService {
 
             ResponseEntity<String> response = restTemplate.exchange(url.toURI(), HttpMethod.GET, entity, String.class);
             KakaoResponse kakaoResponse = objectMapper.readValue(response.getBody(), KakaoResponse.class);
+            if (kakaoResponse.getDocuments().isEmpty()) {
+                return null;
+            }
             return new Coordinates(kakaoResponse.getDocuments().get(0).getY(), kakaoResponse.getDocuments().get(0).getX());
         } catch (Exception e){
             throw new KakaoLocalServiceErrorException();

--- a/src/main/java/nbdream/farm/service/LandElementsService.java
+++ b/src/main/java/nbdream/farm/service/LandElementsService.java
@@ -152,7 +152,7 @@ public class LandElementsService {
         List<CompletableFuture<Void>> futures = addressMap.entrySet().stream()
                 .map(entry -> kakaoAsyncService.getCoordinatesAsync(entry.getValue())
                         .thenAccept(coordinates -> {
-                            coordinatesMap.put(entry.getKey(), coordinates);
+                            if (coordinates != null) coordinatesMap.put(entry.getKey(), coordinates);
                         }))
                 .collect(Collectors.toList());
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();

--- a/src/main/java/nbdream/member/service/MemberService.java
+++ b/src/main/java/nbdream/member/service/MemberService.java
@@ -29,6 +29,8 @@ import nbdream.member.dto.request.WithdrawalReqDto;
 import nbdream.member.exception.MemberNotFoundException;
 import nbdream.member.repository.MemberRepository;
 import nbdream.member.repository.WithdrawalRepository;
+import nbdream.weather.repository.SimpleWeatherRepository;
+import nbdream.weather.repository.WeatherRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +52,8 @@ public class MemberService {
     private final ImageService imageService;
     private final FarmRepository farmRepository;
     private final LandElementsRepository landElementsRepository;
+    private final SimpleWeatherRepository simpleWeatherRepository;
+    private final WeatherRepository weatherRepository;
     private final AccountBookRepository accountBookRepository;
     private final WithdrawalRepository withdrawalRepository;
 
@@ -85,6 +89,7 @@ public class MemberService {
         deleteMyComments(memberId);
         deleteMyBookmarks(memberId);
         deleteLandElements(memberId);
+        deleteWeathers(memberId);
         deleteFarm(memberId);
         deleteAccountBook(memberId);
         member.delete();
@@ -136,6 +141,12 @@ public class MemberService {
         Farm farm = farmRepository.findByMemberId(memberId).orElseThrow(FarmNotFoundException::new);
         LandElements landElements = farm.getLandElements();
         landElementsRepository.delete(landElements);
+    }
+
+    public void deleteWeathers(final Long memberId) {
+        Farm farm = farmRepository.findByMemberId(memberId).orElseThrow(FarmNotFoundException::new);
+        simpleWeatherRepository.deleteAllByFarmId(farm.getId());
+        weatherRepository.deleteAllByFarmId(farm.getId());
     }
 
     public void deleteFarm(final Long memberId) {

--- a/src/main/java/nbdream/member/service/MyProfileService.java
+++ b/src/main/java/nbdream/member/service/MyProfileService.java
@@ -67,8 +67,9 @@ public class MyProfileService {
         landElementsService.saveOrUpdateLandElements(farm, request.getBjdCode(), new Coordinates(request.getLatitude(), request.getLongitude()));
         member.update(request.getNickname(), request.getProfileImageUrl());
 
-        //farm의 위치가 바뀌었다면 기상청 API를 통해 다시 받아오고, 아니라면 DB에서 가져옴
         farm.updateLocation(request.getAddress(),request.getBjdCode(), request.getLatitude(), request.getLongitude());
+
+        //farm의 위치가 바뀌었다면 기상청 API를 통해 다시 받아오고, 아니라면 DB에서 가져옴
         weatherService.getWeathers(memberId);
         updateFarmCrops(farm, request);
     }

--- a/src/main/java/nbdream/weather/domain/SimpleWeather.java
+++ b/src/main/java/nbdream/weather/domain/SimpleWeather.java
@@ -29,7 +29,7 @@ public class SimpleWeather {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "farm_id")
     private Farm farm;
 

--- a/src/main/java/nbdream/weather/domain/Weather.java
+++ b/src/main/java/nbdream/weather/domain/Weather.java
@@ -39,7 +39,7 @@ public class Weather {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "farm_id")
     private Farm farm;
 

--- a/src/main/java/nbdream/weather/repository/SkyRegionCodeRepository.java
+++ b/src/main/java/nbdream/weather/repository/SkyRegionCodeRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface SkyRegionCodeRepository extends JpaRepository<SkyRegionCode, Long> {
 
-    @Query(value = "SELECT s FROM SkyRegionCode s WHERE :address LIKE CONCAT('%', s.regionName, '%') " +
+    @Query(value = "SELECT * FROM sky_region_code WHERE :address LIKE CONCAT('%', region_name, '%') " +
             "LIMIT 1", nativeQuery = true)
     Optional<SkyRegionCode> findByAddress(@Param("address") String address);
 }

--- a/src/main/java/nbdream/weather/repository/TemperatureRegionCodeRepository.java
+++ b/src/main/java/nbdream/weather/repository/TemperatureRegionCodeRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface TemperatureRegionCodeRepository extends JpaRepository<TemperatureRegionCode, Long> {
-    @Query(value = "SELECT t FROM TemperatureRegionCode t WHERE :address LIKE CONCAT('%', t.regionName, '%') " +
+    @Query(value = "SELECT * FROM temperature_region_code WHERE :address LIKE CONCAT('%', region_name, '%') " +
             "LIMIT 1", nativeQuery = true)
     Optional<TemperatureRegionCode> findByAddress(@Param("address") String address);
 }

--- a/src/main/java/nbdream/weather/repository/WeatherRepository.java
+++ b/src/main/java/nbdream/weather/repository/WeatherRepository.java
@@ -2,6 +2,7 @@ package nbdream.weather.repository;
 
 import nbdream.weather.domain.Weather;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -9,6 +10,10 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 public interface WeatherRepository extends JpaRepository<Weather, Long> {
+
+    @Modifying
+    @Query("DELETE FROM Weather s WHERE s.farm.id = :farmId")
+    void deleteAllByFarmId(@Param("farmId") Long farmId);
 
     @Query("SELECT w FROM Weather w WHERE w.farm.id = :farmId AND w.date = :date")
     Optional<Weather> findByFarmIdAndDate(@Param("farmId") Long farmId, @Param("date") LocalDate date);


### PR DESCRIPTION
## Issue
- #ISSUE_NUM


## Overview
- 프로필 수정 시, 카카오 API 의 빈 응답 값으로 인한 오류 수정
- 회원 탈퇴 시, 연관 관계가 잘못되어 있어 없는 엔티티를 삭제함으로써 발생하던 오류 수정


## 참고(optional)
