### PR TITLE
Fix : 프로필 수정 기능 닉네임, 이미지 없어도 가능하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//XML Parsing
+	// XML Parsing
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.1'
+
+	// @Valid
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 }
 

--- a/src/main/java/nbdream/member/controller/MemberController.java
+++ b/src/main/java/nbdream/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package nbdream.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import nbdream.auth.config.AuthenticatedMemberId;
 import nbdream.auth.dto.response.TokenResponse;
@@ -32,10 +33,10 @@ public class MemberController {
         return ApiResponse.ok(myProfileService.getMyPage(memberId));
     }
 
-    @Operation(summary = "프로필 수정")
+    @Operation(summary = "프로필 수정", description = "닉네임, 프로필 사진을 제외하고 필수항목")
     @PutMapping("/profile")
     public ApiResponse<Void> updateProfile(@Parameter(hidden = true) @AuthenticatedMemberId Long memberId,
-                                           @RequestBody UpdateProfileReqDto request) {
+                                           @Valid @RequestBody UpdateProfileReqDto request) {
         myProfileService.updateProfile(memberId, request);
         return ApiResponse.ok();
     }

--- a/src/main/java/nbdream/member/dto/request/UpdateProfileReqDto.java
+++ b/src/main/java/nbdream/member/dto/request/UpdateProfileReqDto.java
@@ -1,9 +1,8 @@
 package nbdream.member.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 
 import java.util.List;
 
@@ -11,12 +10,20 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UpdateProfileReqDto {
     private String nickname;
     private String profileImageUrl;
+
+    @NotNull
     private String address;
+    @NotNull
     private String bjdCode;
+    @NotNull
     private double longitude;
+    @NotNull
     private double latitude;
+    @NotNull
     private List<String> crops;
 }

--- a/src/main/java/nbdream/member/service/MyProfileService.java
+++ b/src/main/java/nbdream/member/service/MyProfileService.java
@@ -62,10 +62,12 @@ public class MyProfileService {
     public void updateProfile(final Long memberId, final UpdateProfileReqDto request) {
         final Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException());
         final Farm farm = farmRepository.findByMemberId(memberId).orElseThrow(FarmNotFoundException::new);
-
         //farm 객체 업데이트 되기 전 실행
         landElementsService.saveOrUpdateLandElements(farm, request.getBjdCode(), new Coordinates(request.getLatitude(), request.getLongitude()));
-        member.update(request.getNickname(), request.getProfileImageUrl());
+        //첫 회원가입시 닉네임, 프사 없이 프로필 수정 할 수 있게
+        if(request.getNickname() != null && request.getProfileImageUrl() != null){
+            member.update(request.getNickname(), request.getProfileImageUrl());
+        }
 
         farm.updateLocation(request.getAddress(),request.getBjdCode(), request.getLatitude(), request.getLongitude());
 


### PR DESCRIPTION
- 첫 가입 시 프로필 이미지, 닉네임에 대한 정보가 없어서 프로필 수정API를 사용할 수 없기 때문에 닉네임, 프로필 이미지 없어도 수정 가능하도록 변경

## Issue
- #ISSUE_NUM


## Overview



## 참고(optional)
