### PR TITLE
Fix : 게시글 삭제 후 내 코멘트 조회 시 버그 해결

### DIFF
--- a/src/main/java/nbdream/bulletin/service/BulletinService.java
+++ b/src/main/java/nbdream/bulletin/service/BulletinService.java
@@ -9,6 +9,7 @@ import nbdream.bulletin.dto.request.BulletinReqDto;
 import nbdream.bulletin.exception.BulletinNotFoundException;
 import nbdream.bulletin.repository.BookmarkRepository;
 import nbdream.bulletin.repository.BulletinRepository;
+import nbdream.comment.repository.CommentRepository;
 import nbdream.common.entity.Status;
 import nbdream.image.domain.Image;
 import nbdream.image.repository.ImageRepository;
@@ -28,6 +29,7 @@ public class BulletinService {
     private final BulletinRepository bulletinRepository;
     private final ImageRepository imageRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final CommentRepository commentRepository;
 
     public Long createBulletin(final Long memberId, final BulletinReqDto request) {
         final Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException());
@@ -57,6 +59,8 @@ public class BulletinService {
 
         imageRepository.findAllByTargetId(bulletinId).stream()
                 .forEach(image -> image.delete());
+        commentRepository.findByBulletinId(bulletinId).stream()
+                        .forEach(comment -> comment.delete());
 
         bulletin.delete(memberId);
     }


### PR DESCRIPTION
기존 : status를 expired로 변경
변경 : DB의 코멘트 삭제

에러 내용
"Unable to find nbdream.bulletin.domain.Bulletin with id 1",

## Issue
- #ISSUE_NUM


## Overview



## 참고(optional)
