### PR TITLE
Fix : 게시글 조회, 댓글 수정 버그

### DIFF
--- a/src/main/java/nbdream/bulletin/exception/CommentNotFoundException.java
+++ b/src/main/java/nbdream/bulletin/exception/CommentNotFoundException.java
@@ -1,0 +1,10 @@
+package nbdream.bulletin.exception;
+
+import nbdream.common.exception.NotFoundException;
+
+public class CommentNotFoundException extends NotFoundException {
+
+    public CommentNotFoundException() {
+        super("댓글을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/nbdream/comment/domain/Comment.java
+++ b/src/main/java/nbdream/comment/domain/Comment.java
@@ -40,6 +40,10 @@ public class Comment extends BaseEntity {
         this.content = content;
     }
 
+    public Comment upateComment(String content){
+        this.content = content;
+        return this;
+    }
     public void delete() {
         this.changeStatus(Status.EXPIRED);
     }

--- a/src/main/java/nbdream/comment/service/CommentService.java
+++ b/src/main/java/nbdream/comment/service/CommentService.java
@@ -4,6 +4,7 @@ package nbdream.comment.service;
 import lombok.RequiredArgsConstructor;
 import nbdream.bulletin.domain.Bulletin;
 import nbdream.bulletin.exception.BulletinNotFoundException;
+import nbdream.bulletin.exception.CommentNotFoundException;
 import nbdream.bulletin.repository.BulletinRepository;
 import nbdream.comment.domain.Comment;
 import nbdream.comment.domain.request.CreatePostRequest;
@@ -60,16 +61,12 @@ public class CommentService {
     }
 
 
+    //
     public void editComment(Long commentId, Long memberId, UpdateCommentRequest request) {
         if (checkAuthorization(commentId, memberId)) {
-            Member commentEditor = memberRepository.getReferenceById(memberId);
-
-            Comment commentEntity = Comment.builder()
-                    .id(commentId)
-                    .author(commentEditor)
-                    .content(request.getCommentDetail())
-                    .build();
-            commentRepository.save(commentEntity);
+            Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
+            comment.upateComment(request.getCommentDetail());
+            commentRepository.save(comment);
         } else {
             throw new UnauthorizedException("NOT_AUTHORIZED");
         }

--- a/src/main/java/nbdream/member/service/MemberService.java
+++ b/src/main/java/nbdream/member/service/MemberService.java
@@ -101,6 +101,7 @@ public class MemberService {
             deleteBulletinComments(bulletin.getId());
             deleteBulletinBookmarks(bulletin.getId());
             deleteBulletinImages(bulletin.getId());
+            bulletinRepository.delete(bulletin);
         }
     }
 


### PR DESCRIPTION
## Issue
- #72 


## Overview

탈퇴한 회원이 작성한 게시글이 있으면 게시글 목록 조회 에러나는 버그 수정
   - 에러 : "Unable to find nbdream.member.domain.Member with id 55",
   - 변경 : DB의 게시글도 같이 삭제되도록 변경
   - 
댓글 수정하는 경우 Id값, status값 null들어가는 버그 수정

## 참고(optional)
